### PR TITLE
docs: link to conventionalcommits.org instead of their repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,4 +66,4 @@ secret-lib.path = "/path/to/core/secret"
 
 ## Commit style
 
-Starting from the `v1.0.0`, Himalaya CLI tries to adopt the [conventional commits specification](https://github.com/conventional-commits/conventionalcommits.org).
+Starting from the `v1.0.0`, Himalaya CLI tries to adopt the [conventional commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary).


### PR DESCRIPTION
Standardizing commit style is welcome, but I was not aware of what Conventional Commits are, and their repository does not describe what the commits are meant to look like. Linking to the summary is IMHO more convenient.

Uh, for clarity: I was just curious about what Conventional Commits are, I am far from being familiar enough with the code base to contribute anything substantial other than hopefully helpful bug reports.