### PR TITLE
chore(deps): bump `cc` crate to 1.2.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.8"
+version = "1.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0cf6e91fde44c773c6ee7ec6bba798504641a8bc2eb7e37a04ffbf4dfaa55a"
+checksum = "c8293772165d9345bdaaa39b45b2109591e63fe5e6fbc23c6ff930a048aa310b"
 dependencies = [
  "jobserver",
  "libc",


### PR DESCRIPTION
seeing some homebrew build issue with cc crate 1.2.8

```
  warning: ring@0.17.8: clang: error: no such file or directory: '-isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk'
  warning: ring@0.17.8: clang: error: no such file or directory: '--sysroot=/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk'; did you mean '--sysroot=/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk'?
  warning: ring@0.17.8: clang: error: no such file or directory: '-isystem/usr/local/include'
  warning: ring@0.17.8: clang: error: no such file or directory: '-isystem/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk/System/Library/Frameworks/OpenGL.framework/Versions/Current/Headers'
  warning: ring@0.17.8: clang: error: no such file or directory: '-fdebug-prefix-map=/private/tmp/himalaya-20250111-7528-cp3u1z/himalaya-1.1.0=.'; did you mean '-fdebug-prefix-map=/private/tmp/himalaya-20250111-7528-cp3u1z/himalaya-1.1.0=.'?
  warning: ring@0.17.8: ToolExecError: Command env -u IPHONEOS_DEPLOYMENT_TARGET LC_ALL="C" "clang" "-O3" "-ffunction-sections" "-fdata-sections" "-fPIC" "-m64" "--target=x86_64-apple-macosx15.2" "-I" "include" "-I" "/private/tmp/himalaya-20250111-7528-cp3u1z/himalaya-1.1.0/target/release/build/ring-476314ec2fa3b2e7/out" "-Wall" "-Wextra" "-fvisibility=hidden" "-std=c1x" "-Wall" "-Wbad-function-cast" "-Wcast-align" "-Wcast-qual" "-Wconversion" "-Wmissing-field-initializers" "-Wmissing-include-dirs" "-Wnested-externs" "-Wredundant-decls" "-Wshadow" "-Wsign-compare" "-Wsign-conversion" "-Wstrict-prototypes" "-Wundef" "-Wuninitialized" "-gfull" "-DNDEBUG" "-o" "/private/tmp/himalaya-20250111-7528-cp3u1z/himalaya-1.1.0/target/release/build/ring-476314ec2fa3b2e7/out/172e8fe49fe517e0-curve25519.o" "-c" "--" "crypto/curve25519/curve25519.c" with args clang did not execute successfully (status code exit status: 1).cargo:warning=clang: error: no such file or directory: '-isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX14.sdk'
```

relates to 
- https://github.com/Homebrew/homebrew-core/pull/203944
- https://github.com/rust-lang/cc-rs/issues/1362