### PR TITLE
Fix gmail doc example

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,11 +295,11 @@ You can also manually edit your own configuration, from scratch:
   folder.aliases.trash = "[Gmail]/Trash"
 
   backend.type = "imap"
-  backend.type.host = "imap.gmail.com"
-  backend.type.port = 993
-  backend.type.login = "example@gmail.com"
-  backend.type.auth.type = "password"
-  backend.type.auth.raw = "*****"
+  backend.host = "imap.gmail.com"
+  backend.port = 993
+  backend.login = "example@gmail.com"
+  backend.auth.type = "password"
+  backend.auth.raw = "*****"
 
   message.send.backend.type = "smtp"
   message.send.backend.host = "smtp.gmail.com"
@@ -546,7 +546,7 @@ You can also manually edit your own configuration, from scratch:
   - `Reply-To`: represents the address the receiver should reply to instead of the `From` header
   - `Cc`: represents the addresses of the other receivers (carbon copy)
   - `Bcc`: represents the addresses of the other hidden receivers (blind carbon copy)
-    
+
   An address can be:
 
   - a single email address `user@domain`


### PR DESCRIPTION
When attempting to use the gmail provider example I was getting errors pointing to the line `backend.type.host`. I compared the configuration to the other examples and found none of them had the additional `type` in their other settings. This worked for me so I'm guessing it's just a typo.