### PR TITLE
docs(readme): fix v1.1 account command examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 </div>
 
 ```
-himalaya envelope list --account posteo --folder Archives.FOSS --page 2
+himalaya envelope list -a posteo --folder Archives.FOSS --page 2
 ```
 
 ![screenshot](./screenshot.jpeg)
@@ -335,7 +335,7 @@ Keeping your password inside the configuration file is good for testing purpose,
   backend.auth.keyring = "gmail-example"
   ```
 
-  Running `himalaya configure -a gmail` will ask for your IMAP password, just paste the one generated previously.
+  Running `himalaya account configure gmail` will ask for your IMAP password, just paste the one generated previously.
 
 #### Using OAuth 2.0
 


### PR DESCRIPTION
## Summary

- update the top-level README example to use subcommand-local account selection
- replace the stale Gmail setup command with the current `account configure <name>` form

## Why

The README still includes two command examples that drifted from the current v1.1 CLI:

- `himalaya envelope list --account ...`
- `himalaya configure -a gmail`

The current CLI expects:

- account selection on the concrete subcommand, e.g. `himalaya envelope list -a posteo ...`
- `himalaya account configure gmail`

## Verification

Validated locally against `himalaya v1.1.0`:

- `himalaya envelope list -a posteo --folder Archives.FOSS --page 2 --help`
- `himalaya account configure gmail --help`
