### PR TITLE
fix(message): set Draft+Seen flags when saving to Drafts folder

### DIFF
--- a/src/email/message/command/save.rs
+++ b/src/email/message/command/save.rs
@@ -6,7 +6,13 @@ use std::{
 
 use clap::Parser;
 use color_eyre::Result;
-use email::{backend::feature::BackendFeatureSource, config::Config, envelope::SingleId};
+use email::{
+    backend::feature::BackendFeatureSource,
+    config::Config,
+    envelope::SingleId,
+    flag::{Flag, Flags},
+    folder::FolderKind,
+};
 use pimalaya_tui::{
     himalaya::backend::BackendBuilder,
     terminal::{cli::printer::Printer, config::TomlConfig as _},
@@ -72,7 +78,17 @@ impl MessageSaveCommand {
                 .join("\r\n")
         };
 
-        let id = backend.add_message(folder, msg.as_bytes()).await?;
+        let id = if FolderKind::matches_drafts(folder) {
+            backend
+                .add_message_with_flags(
+                    folder,
+                    msg.as_bytes(),
+                    &Flags::from_iter([Flag::Seen, Flag::Draft]),
+                )
+                .await?
+        } else {
+            backend.add_message(folder, msg.as_bytes()).await?
+        };
 
         printer.out(MessageAdded { folder, id })
     }
@@ -97,5 +113,21 @@ impl Serialize for MessageAdded<'_> {
         state.serialize_field("folder", self.folder)?;
         state.serialize_field("id", self.id.as_str())?;
         state.end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use email::folder::FolderKind;
+
+    #[test]
+    fn drafts_folder_detected() {
+        assert!(FolderKind::matches_drafts("Drafts"));
+        assert!(FolderKind::matches_drafts("drafts"));
+        assert!(FolderKind::matches_drafts("DRAFTS"));
+        assert!(!FolderKind::matches_drafts("Draft"));
+        assert!(!FolderKind::matches_drafts("INBOX"));
+        assert!(!FolderKind::matches_drafts("Sent"));
+        assert!(!FolderKind::matches_drafts("Trash"));
     }
 }

--- a/src/email/message/template/command/save.rs
+++ b/src/email/message/template/command/save.rs
@@ -6,7 +6,13 @@ use std::{
 
 use clap::Parser;
 use color_eyre::Result;
-use email::{backend::feature::BackendFeatureSource, config::Config, envelope::SingleId};
+use email::{
+    backend::feature::BackendFeatureSource,
+    config::Config,
+    envelope::SingleId,
+    flag::{Flag, Flags},
+    folder::FolderKind,
+};
 use mml::MmlCompilerBuilder;
 use pimalaya_tui::{
     himalaya::backend::BackendBuilder,
@@ -86,9 +92,17 @@ impl TemplateSaveCommand {
 
         let msg = compiler.build(tpl.as_str())?.compile().await?.into_vec()?;
 
-        backend.add_message(folder, &msg).await?;
-
-        let id = backend.add_message(folder, &msg).await?;
+        let id = if FolderKind::matches_drafts(folder) {
+            backend
+                .add_message_with_flags(
+                    folder,
+                    &msg,
+                    &Flags::from_iter([Flag::Seen, Flag::Draft]),
+                )
+                .await?
+        } else {
+            backend.add_message(folder, &msg).await?
+        };
 
         printer.out(TemplateAdded { folder, id })
     }


### PR DESCRIPTION
## Summary

- `message save` and `template save` now set `\Seen` + `\Draft`
  flags when the target folder is the Drafts folder
- Fixes duplicate `add_message` call in `template save` (saved
  the message twice)
- Matches existing behaviour in the interactive editor path
  (`pimalaya-tui/src/himalaya/editor.rs`)

## Test plan

- [x] `cargo test` passes (includes new unit test for folder detection)
- [x] `cargo clippy` passes
- [x] Manual test: `message save --folder Drafts` shows as
  proper draft with `[Seen, Draft]` flags (DavMail/Exchange)
- [x] Manual test: `template save --folder Drafts` creates
  exactly one message with Draft flag (no duplicate)
- [x] Manual test: saving to non-Drafts folder does not add
  Draft flag

Closes #662