### PR TITLE
feat(message): add --yes flag to reply command for non-interactive sending

### DIFF
--- a/src/email/message/arg/mod.rs
+++ b/src/email/message/arg/mod.rs
@@ -3,6 +3,7 @@ use clap::Parser;
 pub mod body;
 pub mod header;
 pub mod reply;
+pub mod yes;
 
 /// The raw message argument parser.
 #[derive(Debug, Parser)]

--- a/src/email/message/arg/yes.rs
+++ b/src/email/message/arg/yes.rs
@@ -1,0 +1,13 @@
+use clap::Parser;
+
+/// The skip-editor argument parser.
+#[derive(Debug, Parser)]
+pub struct MessageYesArg {
+    /// Skip the editor and send the message immediately.
+    ///
+    /// This argument requires --body to be set. When provided, the
+    /// message is compiled and sent directly without opening the
+    /// editor defined in $EDITOR.
+    #[arg(long, short = 'y')]
+    pub yes: bool,
+}

--- a/src/email/message/command/reply.rs
+++ b/src/email/message/command/reply.rs
@@ -1,8 +1,12 @@
 use std::sync::Arc;
 
 use clap::Parser;
-use color_eyre::{eyre::eyre, Result};
+use color_eyre::{
+    eyre::{bail, eyre},
+    Result,
+};
 use email::{backend::feature::BackendFeatureSource, config::Config, flag::Flag};
+use mml::MmlCompilerBuilder;
 use pimalaya_tui::{
     himalaya::{backend::BackendBuilder, editor},
     terminal::{cli::printer::Printer, config::TomlConfig as _},
@@ -14,7 +18,10 @@ use crate::{
     config::TomlConfig,
     envelope::arg::ids::EnvelopeIdArg,
     folder::arg::name::FolderNameOptionalFlag,
-    message::arg::{body::MessageRawBodyArg, header::HeaderRawArgs, reply::MessageReplyAllArg},
+    message::arg::{
+        body::MessageRawBodyArg, header::HeaderRawArgs, reply::MessageReplyAllArg,
+        yes::MessageYesArg,
+    },
 };
 
 /// Reply to the message associated to the given envelope id.
@@ -23,6 +30,10 @@ use crate::{
 /// editor defined in your environment variable $EDITOR. When the
 /// edition process finishes, you can choose between saving or sending
 /// the final message.
+///
+/// When --yes is given together with --body, the editor is skipped
+/// and the reply is sent immediately. This is useful for automated
+/// or scripted workflows that do not have an interactive terminal.
 #[derive(Debug, Parser)]
 pub struct MessageReplyCommand {
     #[command(flatten)]
@@ -39,6 +50,9 @@ pub struct MessageReplyCommand {
 
     #[command(flatten)]
     pub body: MessageRawBodyArg,
+
+    #[command(flatten)]
+    pub yes: MessageYesArg,
 
     #[command(flatten)]
     pub account: AccountNameFlag,
@@ -71,6 +85,11 @@ impl MessageReplyCommand {
         .await?;
 
         let id = self.envelope.id;
+
+        if self.yes.yes && self.body.is_empty() {
+            bail!("--yes requires --body to be set");
+        }
+
         let tpl = backend
             .get_messages(folder, &[id])
             .await?
@@ -83,7 +102,18 @@ impl MessageReplyCommand {
             .build()
             .await?;
 
-        editor::edit_tpl_with_editor(account_config, printer, &backend, tpl).await?;
+        if self.yes.yes {
+            let email = MmlCompilerBuilder::new()
+                .build(tpl.as_str())?
+                .compile()
+                .await?
+                .into_vec()?;
+
+            backend.send_message_then_save_copy(&email).await?;
+            printer.out("Message successfully sent!\n")?;
+        } else {
+            editor::edit_tpl_with_editor(account_config, printer, &backend, tpl).await?;
+        }
 
         backend.add_flag(folder, &[id], Flag::Answered).await?;
 


### PR DESCRIPTION
Closes #666

## Problem

`himalaya message reply` always opens an interactive editor (`$EDITOR`), making it impossible to use in automated or scripted workflows (e.g. CI pipelines, email agents).

The existing workaround — `himalaya template reply <id> | himalaya message send` — does **not** produce a proper reply: the generated template lacks `In-Reply-To` and `References` headers, so recipients see a new thread instead of a reply.

## Solution

Add a `--yes` / `-y` flag to `message reply`. When provided together with `--body`, the editor is skipped and the message is compiled and sent immediately via `send_message_then_save_copy`, preserving all reply headers (`In-Reply-To`, `References`) that `to_reply_tpl_builder` correctly sets.

If `--yes` is given without `--body`, the command exits with a clear error:
```
--yes requires --body to be set
```

## Changes

- `src/email/message/arg/yes.rs` — new `MessageYesArg` struct with `--yes` / `-y` flag
- `src/email/message/arg/mod.rs` — export `yes` module
- `src/email/message/command/reply.rs` — add `yes` field to `MessageReplyCommand`; branch on `--yes` to send directly or fall back to the existing editor flow

## Usage

```bash
# Non-interactive reply — skips editor, correct threading headers
himalaya message reply --yes <id> "Approved."

# Interactive reply — unchanged behaviour
himalaya message reply <id>
```

## Testing

Tested locally against a real IMAP/SMTP mailbox (Tencent Exmail). Verified:

- `himalaya message reply --yes <id> "text"` sends immediately without opening the editor
- The sent message is correctly threaded — recipient sees it as a reply with proper `In-Reply-To` and `References` headers, not a new email
- `himalaya message reply --yes <id>` (without `--body`) exits with the expected error: `--yes requires --body to be set`
- `himalaya message reply <id>` (without `--yes`) still opens `$EDITOR` as before — no regression