### PR TITLE
Update config.sample.toml

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -319,7 +319,7 @@ template.forward.quote-headline = "-------- Forwarded Message --------\n"
 
 # Defines the sign command.
 #
-#pgp.sign-cmd = "gpg --sign --quiet --armor"
+#pgp.sign-cmd = "gpg --detach-sign --quiet --armor"
 
 # Defines the verify command.
 #


### PR DESCRIPTION
Fix `gpg.sign-cmd` example: `--detach-sign` flag shold be used instead of `--sign` for a correct PGP signature.