### PR TITLE
fix: prevent panic when message send receives invalid email

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1853,6 +1853,7 @@ dependencies = [
  "clap_mangen",
  "color-eyre",
  "email-lib",
+ "mail-parser",
  "mml-lib",
  "once_cell",
  "open",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ clap_complete = "4.4"
 clap_mangen = "0.2"
 color-eyre = "0.6"
 email-lib = { version = "0.27", default-features = false, features = ["tokio-rustls", "derive", "thread"] }
+mail-parser = "0.9"
 mml-lib = { version = "1", default-features = false, features = ["compiler", "interpreter", "derive"]  }
 once_cell = "1.16"
 open = "5.3"

--- a/src/email/message/command/send.rs
+++ b/src/email/message/command/send.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
-use color_eyre::Result;
+use color_eyre::{eyre::bail, Result};
 use email::{backend::feature::BackendFeatureSource, config::Config};
+use mail_parser::MessageParser;
 use pimalaya_tui::{
     himalaya::backend::BackendBuilder,
     terminal::{cli::printer::Printer, config::TomlConfig as _},
@@ -59,6 +60,10 @@ impl MessageSendCommand {
                 .collect::<Vec<_>>()
                 .join("\r\n")
         };
+
+        if MessageParser::new().parse(msg.as_bytes()).is_none() {
+            bail!("cannot parse raw email message.\nHint: pipe a valid .eml file, e.g. `cat msg.eml | himalaya message send`");
+        }
 
         backend.send_message_then_save_copy(msg.as_bytes()).await?;
 


### PR DESCRIPTION
The command `himalaya message send` panics with "index out of bounds: the
len is 0 but the index is 0" in mail-parser when given email content that
cannot be parsed.

Root cause:

  email-lib's SmtpContext::send() passes raw bytes to
  mail_parser::MessageParser::parse(). When parsing fails, the code
  substitutes Message::default(), which has an empty "parts" vector.
  The subsequent into_smtp_msg() calls msg.headers(), which internally
  calls msg.root_part(), which accesses self.parts[0] — panicking on
  the empty vector.

Fix:

  Add mail-parser as an explicit dependency and pre-validate the raw
  message in MessageSendCommand::execute() before handing it off to
  email-lib. If parsing fails, return a clean error with a hint about
  how to use the command correctly (pipe a valid .eml file).

This is a defensive fix at the himalaya level. The underlying issue in
email-lib (using Default::default() when parsing fails, then calling
methods that assume a non-empty message) could also be fixed there, but
this change prevents the panic regardless of which email-lib version is
used.