### PR TITLE
docs: add multi-language README support

### DIFF
--- a/README-DE.md
+++ b/README-DE.md
@@ -1,0 +1,429 @@
+<div align="center">
+  <img src="./logo.svg" alt="Logo" width="128" height="128" />
+  <h1>📫 Himalaya</h1>
+  <p>CLI zur E-Mail-Verwaltung</p>
+  <p>
+    <a href="https://github.com/pimalaya/himalaya/releases/latest"><img alt="Release" src="https://img.shields.io/github/v/release/pimalaya/himalaya?color=success"/></a>
+    <a href="https://repology.org/project/himalaya/versions"><img alt="Repology" src="https://img.shields.io/repology/repositories/himalaya?color=success"></a>
+    <a href="https://matrix.to/#/#pimalaya:matrix.org"><img alt="Matrix" src="https://img.shields.io/badge/chat-%23pimalaya-blue?style=flat&logo=matrix&logoColor=white"/></a>
+    <a href="https://fosstodon.org/@pimalaya"><img alt="Mastodon" src="https://img.shields.io/badge/news-%40pimalaya-blue?style=flat&logo=mastodon&logoColor=white"/></a>
+  </p>
+  <p>
+    <strong>Sprachen / Languages:</strong>
+    <a href="README.md">English</a> ·
+    <a href="README-ZH.md">中文</a> ·
+    <a href="README-ES.md">Español</a> ·
+    <a href="README-FR.md">Français</a> ·
+    <a href="README-PT.md">Português</a> ·
+    <a href="README-RU.md">Русский</a> ·
+    <a href="README-DE.md">Deutsch</a>
+  </p>
+</div>
+
+```
+himalaya envelopes list --account posteo -m Archives.FOSS --page 2
+```
+
+![screenshot](./screenshot.jpeg)
+
+> [!IMPORTANT]
+> Dieses README dokumentiert Himalaya v2, das **noch nicht veröffentlicht** ist. Wenn Sie v1 verwenden (`himalaya v1.2.0` oder früher), lesen Sie stattdessen das [README v1.2.0](https://github.com/pimalaya/himalaya/blob/v1.2.0/README.md). Der Leitfaden [MIGRATION.md](./MIGRATION.md) führt v1-Nutzer durch die Breaking Changes.
+
+## Inhaltsverzeichnis
+
+- [Funktionen](#funktionen)
+- [Installation](#installation)
+  - [Vorkompiliertes Binary](#vorkompiliertes-binary)
+  - [Cargo](#cargo)
+  - [Arch Linux](#arch-linux)
+  - [Homebrew](#homebrew)
+  - [Scoop](#scoop)
+  - [Fedora Linux/CentOS/RHEL](#fedora-linuxcentosrhel)
+  - [Nix](#nix)
+  - [Quellcode](#quellcode)
+- [Konfiguration](#konfiguration)
+- [Verwendung](#verwendung)
+  - [Gemeinsame API](#gemeinsame-api)
+  - [Protokollspezifische APIs](#protokollspezifische-apis)
+  - [Nachrichten verfassen](#nachrichten-verfassen)
+  - [Nachrichten lesen](#nachrichten-lesen)
+  - [Sitzungen wiederverwenden](#sitzungen-wiederverwenden)
+- [Schnittstellen](#schnittstellen)
+- [FAQ](#faq)
+- [Social Media](#social-media)
+- [Sponsoring](#sponsoring)
+
+## Funktionen
+
+- **Gemeinsame API**, die `mailboxes`, `envelopes`, `flags`, `messages` und `attachments` dem aktiven Backend zuordnet
+- **Protokollspezifische APIs**, die die vollständige Oberfläche jedes Backends bereitstellen (`himalaya imap/smtp/maildir/jmap…`)
+- **IMAP**-Unterstützung <sup>[rfc9051](https://www.iana.org/go/rfc9051)</sup> (erfordert das Feature `imap`)
+- **JMAP**-Unterstützung <sup>[rfc8620](https://www.iana.org/go/rfc8620), [rfc8621](https://www.iana.org/go/rfc8621)</sup> (erfordert das Feature `jmap`)
+- **Maildir**-Unterstützung (erfordert das Feature `maildir`)
+- **SMTP**-Backend <sup>[rfc5321](https://www.iana.org/go/rfc5321)</sup> (erfordert das Feature `smtp`)
+- **TLS**-Unterstützung:
+  - [native-tls](https://crates.io/crates/native-tls) (erfordert das Feature `native-tls`)
+  - [rustls](https://crates.io/crates/rustls):
+    - AWS-LC-Kryptoprovider (erfordert das Feature `rustls-aws`)
+    - Ring-Kryptoprovider (erfordert das Feature `rustls-ring`)
+- **SASL**-Unterstützung: anonymous, login, plain, oauthbearer, xoauth2, scram-sha-256
+- **Provider-Erkennung**-Assistent auf Basis von [io-discovery](https://github.com/pimalaya/io-discovery): Thunderbird Autoconfiguration, PACC und RFC-6186-SRV-Lookups
+- **TOML**-Konfiguration mit Multi-Account-Unterstützung
+- **JSON**-Ausgabe über `--json`
+
+*Himalaya CLI ist in [Rust](https://www.rust-lang.org/) geschrieben und nutzt [cargo features](https://doc.rust-lang.org/cargo/reference/features.html), um Funktionen zu aktivieren oder zu deaktivieren. Standard-Features finden Sie im Abschnitt `features` der [`Cargo.toml`](./Cargo.toml#L18) oder auf [docs.rs](https://docs.rs/crate/himalaya/latest/features).*
+
+## Installation
+
+### Vorkompiliertes Binary
+
+Himalaya CLI kann mit dem Installer `install.sh` installiert werden:
+
+*Als root:*
+
+```
+curl -sSL https://raw.githubusercontent.com/pimalaya/himalaya/master/install.sh | sudo sh
+```
+
+*Als normaler Benutzer:*
+
+```
+curl -sSL https://raw.githubusercontent.com/pimalaya/himalaya/master/install.sh | PREFIX=~/.local sh
+```
+
+Diese Befehle installieren das neueste Binary aus dem GitHub-Abschnitt [releases](https://github.com/pimalaya/himalaya/releases).
+
+Wenn Sie eine aktuellere Version als das neueste Release benötigen, schauen Sie im GitHub-Workflow [releases](https://github.com/pimalaya/himalaya/actions/workflows/releases.yml) nach dem Abschnitt *Artifacts*. Dort finden Sie ein vorkompiliertes Binary für Ihr Betriebssystem. Diese Binaries werden aus dem Branch `master` gebaut.
+
+*Solche Binaries werden mit den Standard-cargo-features gebaut. Wenn Sie mehr Features benötigen, verwenden Sie bitte eine andere Installationsmethode.*
+
+### Cargo
+
+Himalaya CLI kann mit [cargo](https://doc.rust-lang.org/cargo/) installiert werden:
+
+```
+cargo install himalaya --locked
+```
+
+Nur mit IMAP-Unterstützung:
+
+```
+cargo install himalaya --locked --no-default-features --features imap
+```
+
+Sie können auch das Git-Repository für eine aktuellere (aber weniger stabile) Version verwenden:
+
+```
+cargo install --locked --git https://github.com/pimalaya/himalaya.git
+```
+
+### Arch Linux
+
+Himalaya CLI kann auf [Arch Linux](https://archlinux.org/) über das Community-Repository installiert werden:
+
+```
+pacman -S himalaya
+```
+
+oder über das [User Repository](https://aur.archlinux.org/):
+
+```
+git clone https://aur.archlinux.org/himalaya-git.git
+cd himalaya-git
+makepkg -isc
+```
+
+Wenn Sie [yay](https://github.com/Jguer/yay) verwenden, ist es noch einfacher:
+
+```
+yay -S himalaya-git
+```
+
+### Homebrew
+
+Himalaya CLI kann mit [Homebrew](https://brew.sh/) installiert werden:
+
+```
+brew install himalaya
+```
+
+Hinweis: cargo features sind nicht mit brew kompatibel. Wenn Sie ein anderes Feature-Set benötigen, verwenden Sie bitte eine andere Installationsmethode.
+
+### Scoop
+
+Himalaya CLI kann mit [Scoop](https://scoop.sh/) installiert werden:
+
+```
+scoop install himalaya
+```
+
+### Fedora Linux/CentOS/RHEL
+
+Himalaya CLI kann auf [Fedora Linux](https://fedoraproject.org/)/CentOS/RHEL über das [COPR](https://copr.fedorainfracloud.org/coprs/atim/himalaya/)-Repository installiert werden:
+
+```
+dnf copr enable atim/himalaya
+dnf install himalaya
+```
+
+### Nix
+
+Himalaya CLI kann mit [Nix](https://serokell.io/blog/what-is-nix) installiert werden:
+
+```
+nix-env -i himalaya
+```
+
+Sie können auch das Git-Repository für eine aktuellere (aber weniger stabile) Version verwenden:
+
+```
+nix-env -if https://github.com/pimalaya/himalaya/archive/master.tar.gz
+```
+
+*Oder aus dem Checkout des Quellbaums:*
+
+```
+nix-env -if .
+```
+
+Wenn Sie die [Flakes](https://nixos.wiki/wiki/Flakes)-Funktion aktiviert haben:
+
+```
+nix profile install github:pimalaya/himalaya
+```
+
+*Oder aus dem Checkout des Quellbaums:*
+
+```
+nix profile install
+```
+
+*Sie können Himalaya auch direkt ohne Installation ausführen:*
+
+```
+nix run github:pimalaya/himalaya
+```
+
+### Quellcode
+
+```
+git clone https://github.com/pimalaya/himalaya
+cd himalaya
+nix develop --command cargo build --release
+```
+
+*Binaries sind im Ordner `target/release` verfügbar.*
+
+## Konfiguration
+
+Führen Sie einfach `himalaya` aus. Wenn keine Konfigurationsdatei gefunden wird, fragt der Assistent nach Kontoname und E-Mail-Adresse, führt [Provider-Erkennung](https://github.com/pimalaya/io-discovery) durch (PACC → Thunderbird Autoconfiguration → RFC 6186 SRV), füllt die IMAP/SMTP- (oder JMAP-)Eingaben mit den erkannten Standardwerten und schreibt das Ergebnis auf die Festplatte.
+
+Konten können später mit `himalaya account configure <name>` (neu) konfiguriert werden. In diesem Modus überspringt der Assistent die Erkennung: Er verwendet die vorhandenen Werte als Standardwerte für die Eingaben.
+
+Sie können die Konfiguration auch manuell schreiben:
+
+- Kopieren Sie die dokumentierte [./config.sample.toml](./config.sample.toml)
+- Fügen Sie sie in einen der folgenden Pfade ein:
+  - `$XDG_CONFIG_HOME/himalaya/config.toml`
+  - `$HOME/.config/himalaya/config.toml`
+  - `$HOME/.himalayarc`
+- Kommentieren Sie die gewünschten Optionen ein oder aus
+
+…oder übergeben Sie `-c <PATH>` / setzen Sie `HIMALAYA_CONFIG=<PATH>`. Mehrere Pfade können gleichzeitig übergeben werden, getrennt durch `:`; der erste ist die Basis und die restlichen werden darüber tief zusammengeführt.
+
+## Verwendung
+
+### Gemeinsame API
+
+Backend-unabhängige Befehle arbeiten mit dem ersten konfigurierten Backend des Kontos oder dem mit `-b/--backend` ausgewählten:
+
+```
+himalaya mailboxes list
+himalaya envelopes list -m INBOX --page 2
+himalaya envelopes search from alice and after 2026-01-01 order by date desc
+himalaya flags add -m INBOX --flag seen 1:3,5
+himalaya messages copy --from INBOX --to Archives 42
+himalaya attachments download -m INBOX 42
+```
+
+Wenn der Alias `inbox` unter `[mailbox.alias]` konfiguriert ist, wird `-m/--mailbox` optional: Gemeinsame Befehle greifen auf diese ID zurück. Mit `[mailbox.alias] inbox = "INBOX"` verkürzen sich die Aufrufe oben zu `envelopes list --page 2`, `flags add --flag seen 1:3,5` usw.
+
+`envelopes list` ist einfache Paginierung, sortiert nach Datum absteigend. Zum Filtern oder Sortieren verwenden Sie `envelopes search` mit einer abschließenden Abfrage für `date`, `after`, `from`, `to`, `subject`, `body`, `flag`-Bedingungen (kombiniert mit `and`, `or`, `not`, gruppiert mit Klammern) und einer Sortierkette `order by date|from|to|subject [asc|desc]`. Datums-Klauseln beziehen sich auf den `Date:`-Header (Sendezeitpunkt) auf jedem Backend.
+
+Die gemeinsame Oberfläche ist eine strikte kleinst-gemeinsame-Nenner-Teilmenge über IMAP, JMAP und Maildir. Operationen, die sich nicht verallgemeinern lassen (Mailbox-Rollen, Attribut-Flags, JMAP-spezifische Abfragen…), befinden sich unter den protokollspezifischen Unterbefehlen.
+
+### Protokollspezifische APIs
+
+Jedes Backend stellt seine vollständige native API in einer eigenen Untergruppe bereit:
+
+```
+himalaya imap mailboxes select INBOX
+himalaya imap mailboxes status INBOX
+himalaya imap mailboxes subscribe INBOX
+
+himalaya jmap mailboxes query --role drafts
+himalaya jmap identity get
+himalaya jmap vacation get
+
+himalaya maildir create Archives
+himalaya maildir messages save -m ~/Mail/example/Archives < message.eml
+
+himalaya smtp messages send < message.eml
+```
+
+Die Flag `-b/--backend` wird nur von den gemeinsamen Befehlen verarbeitet; Protokoll-Unterbefehle verwenden immer ihr eigenes Backend.
+
+### Nachrichten verfassen
+
+Die integrierten Befehle `messages compose` / `reply` / `forward` decken einfache Fälle über CLI-Flags ab:
+
+```
+himalaya messages compose --from me@example.org --to you@example.org \
+    --subject "Hello" --body "Hi!" --send
+```
+
+Für reichhaltigere Komposition (Multipart-MIME, MML-Direktiven, Signierung/Verschlüsselung, Editor-gesteuerte Workflows…), richten Sie einen benutzerdefinierten Composer in `[message.composer.*]` ein und rufen ihn mit den `-with`-Varianten auf. Zum Beispiel mit [`mml`](https://github.com/pimalaya/mml):
+
+```toml
+[message.composer.mml]
+command = "mml compose"
+default = true
+```
+
+```
+himalaya messages compose-with
+himalaya messages reply-with -m INBOX 42 --send
+himalaya messages forward-with -m INBOX 42 --send
+himalaya messages mailto 'mailto:bob@example.org?subject=Hi&body=Hello'
+```
+
+`messages mailto <URI>` parst eine RFC-6068-`mailto:`-URI (Empfängerliste im Pfad, Query-Parameter `to` / `cc` / `bcc` / `subject` / `body`), erstellt ein RFC-5322-Entwurfsgerüst mit vorausgefüllten Headern und leitet es auf stdin an den benannten (oder Standard-)Composer zur Bearbeitung weiter. Die Ausgabe des Composers wird wie bei den anderen `-with`-Varianten über `--save` / `--send` geroutet. Nützlich als Desktop-`mailto:`-Handler.
+
+### Nachrichten lesen
+
+Der integrierte Befehl `messages read` rendert eine Nachricht mit Himalayas Standard-Formatter. Für benutzerdefiniertes Rendering deklarieren Sie einen Reader in `[message.reader.*]` und rufen `read-with` auf:
+
+```toml
+[message.reader.mml]
+command = "mml read"
+default = true
+```
+
+```
+himalaya messages read-with -m INBOX 42
+```
+
+### Sitzungen wiederverwenden
+
+Jeder Aufruf öffnet standardmäßig eine frische TCP+TLS+SASL-Sitzung. Um den Handshake über viele Befehle zu amortisieren, kombinieren Sie Himalaya mit [`sirup`](https://github.com/pimalaya/sirup): `sirup` stellt eine vorauthentifizierte IMAP/SMTP-Sitzung über einen Unix-Socket bereit, und Himalaya kann seinen `imap.server` / `smtp.server` auf diesen Socket zeigen.
+
+## Schnittstellen
+
+Diese Schnittstellen sind auf Himalaya CLI aufgebaut, um die Benutzererfahrung zu verbessern:
+
+- [pimalaya/himalaya-tui](https://github.com/pimalaya/himalaya-tui): offizielle TUI (in aktiver Entwicklung)
+- [pimalaya/himalaya-vim](https://github.com/pimalaya/himalaya-vim): Vim-Plugin
+- [dantecatalfamo/himalaya-emacs](https://github.com/dantecatalfamo/himalaya-emacs): Emacs-Plugin
+- [jns/himalaya](https://www.raycast.com/jns/himalaya): Raycast-Erweiterung
+- [openclaw/openclaw](https://github.com/openclaw/openclaw/blob/main/skills/himalaya/SKILL.md): OpenClaw SKILL
+- [parisni/dfzf](https://github.com/parisni/dfzf): dfzf-Integration
+
+## FAQ
+
+<details>
+  <summary>Wie unterscheidet es sich von aerc, mutt oder alpine?</summary>
+
+  Aerc, mutt und alpine können als Terminal User Interfaces (TUI) kategorisiert werden. Wenn das Programm ausgeführt wird, ist Ihr Terminal in eine Event-Schleife gesperrt und Sie interagieren mit Ihren E-Mails über Tastenkürzel.
+
+  Himalaya ist eine Command-Line Interface (CLI). Es gibt keine Event-Schleife: Sie interagieren mit Ihren E-Mails über Shell-Befehle, zustandslos.
+
+  Eine dedizierte TUI ([himalaya-tui](https://github.com/pimalaya/himalaya-tui)) wird aktiv auf denselben Pimalaya-Bibliotheken entwickelt.
+</details>
+
+<details>
+  <summary>Wie werden Secrets aufgelöst?</summary>
+
+  Jedes Feld `*.passwd` / `*.password` / `*.token` akzeptiert entweder ein rohes Literal oder einen Shell-Befehl, der das Secret auf stdout ausgibt. Die rohe Form ist praktisch zum Testen, sollte aber nicht in der Produktion verwendet werden:
+
+  ```toml
+  imap.sasl.plain.passwd.raw = "***"
+  imap.sasl.plain.passwd.command = "pass show example"
+  imap.sasl.plain.passwd.command = ["pass", "show", "example"]
+  ```
+
+  Native Keyring-Unterstützung wurde in v2 entfernt. Verwenden Sie [pimalaya/mimosa](https://github.com/pimalaya/mimosa) (oder `pass`, `secret-tool`, `gopass`…) als `command`.
+</details>
+
+<details>
+  <summary>Wie wird OAuth 2.0 behandelt?</summary>
+
+  v2 enthält keine OAuth-Flows. Verwenden Sie [pimalaya/ortie](https://github.com/pimalaya/ortie) (oder einen anderen Token-Broker), um ein Access Token zu erhalten, und binden Sie es als `command` ein, der das Token auf stdout zurückgibt. Für JMAP zeigen Sie `jmap.auth.bearer.token.command` auf den Broker; für IMAP/SMTP leiten Sie den Bearer über einen SASL-Mechanismus, der ein command-basiertes Passwort verarbeitet.
+</details>
+
+<details>
+  <summary>Wie erkennt der Assistent IMAP/SMTP/JMAP-Konfigurationen?</summary>
+
+  Der Assistent führt drei Erkennungsmechanismen nacheinander auf der E-Mail-Adressdomäne aus; der erste nicht-leere Treffer gewinnt:
+
+  1. **PACC** <sup>[draft-ietf-mailmaint-pacc-02](https://datatracker.ietf.org/doc/html/draft-ietf-mailmaint-pacc-02)</sup>: Well-known JSON, digest-verifiziert gegen den `_ua-auto-config`-TXT-Eintrag.
+  2. **Thunderbird Autoconfiguration**: ISP main / well-known / ISPDB-Lookups, dann MX-basierter Retry, dann die `mailconf=<URL>`-TXT-Weiterleitung.
+  3. **RFC 6186 SRV**: `_imap._tcp`, `_imaps._tcp`, `_submission._tcp`-Lookups, zu einem einzelnen Bericht zusammengefasst.
+
+  Siehe [io-discovery](https://github.com/pimalaya/io-discovery) für die vollständige Kette.
+</details>
+
+<details>
+  <summary>Wie debuggt man Himalaya CLI?</summary>
+
+  Verwenden Sie `--log-level <level>` (Alias `--log`), wobei `<level>` einer von `off`, `error`, `warn`, `info`, `debug`, `trace` ist:
+
+  ```
+  himalaya --log trace mailboxes list
+  ```
+
+  Die Umgebungsvariable `RUST_LOG` wird berücksichtigt, wenn `--log` nicht übergeben wird, und unterstützt Filter pro Ziel (siehe die [`env_logger`-Dokumentation](https://docs.rs/env_logger/latest/env_logger/#enabling-logging)). `RUST_BACKTRACE=1` aktiviert vollständige Fehler-Backtraces.
+
+  Logs werden nach `stderr` geschrieben und können leicht in eine Datei umgeleitet werden:
+
+  ```
+  himalaya --log trace mailboxes list 2>/tmp/himalaya.log
+  ```
+
+  Sie können Logs auch direkt in eine Datei senden über `--log-file <path>`:
+
+  ```
+  himalaya --log trace --log-file /tmp/himalaya.log mailboxes list
+  ```
+</details>
+
+<details>
+  <summary>Wie deaktiviert man Farbausgabe?</summary>
+
+  Setzen Sie `NO_COLOR=1` in Ihrer Umgebung.
+</details>
+
+## Social Media
+
+- Chat auf [Matrix](https://matrix.to/#/#pimalaya:matrix.org)
+- Neuigkeiten auf [Mastodon](https://fosstodon.org/@pimalaya) oder [RSS](https://fosstodon.org/@pimalaya.rss)
+- E-Mail an [pimalaya.org@posteo.net](mailto:pimalaya.org@posteo.net)
+
+## Sponsoring
+
+[![nlnet](https://nlnet.nl/logo/banner-160x60.png)](https://nlnet.nl/)
+
+Besonderer Dank an die [NLnet-Stiftung](https://nlnet.nl/) und die [Europäische Kommission](https://www.ngi.eu/), die das Projekt seit Jahren finanziell unterstützen:
+
+- 2022 → 2023: [NGI Assure](https://nlnet.nl/project/Himalaya/)
+- 2023 → 2024: [NGI Zero Entrust](https://nlnet.nl/project/Pimalaya/)
+- 2024 → 2026: [NGI Zero Core](https://nlnet.nl/project/Pimalaya-PIM/)
+- *2027 in Vorbereitung…*
+
+Wenn Ihnen das Projekt gefällt, können Sie gerne über einen der folgenden Anbieter spenden:
+
+[![GitHub](https://img.shields.io/badge/-GitHub%20Sponsors-fafbfc?logo=GitHub%20Sponsors)](https://github.com/sponsors/soywod)
+[![Ko-fi](https://img.shields.io/badge/-Ko--fi-ff5e5a?logo=Ko-fi&logoColor=ffffff)](https://ko-fi.com/soywod)
+[![Buy Me a Coffee](https://img.shields.io/badge/-Buy%20Me%20a%20Coffee-ffdd00?logo=Buy%20Me%20A%20Coffee&logoColor=000000)](https://www.buymeacoffee.com/soywod)
+[![Liberapay](https://img.shields.io/badge/-Liberapay-f6c915?logo=Liberapay&logoColor=222222)](https://liberapay.com/soywod)
+[![thanks.dev](https://img.shields.io/badge/-thanks.dev-000000?logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQuMDk3IiBoZWlnaHQ9IjE3LjU5NyIgY2xhc3M9InctMzYgbWwtMiBsZzpteC0wIHByaW50Om14LTAgcHJpbnQ6aW52ZXJ0IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxwYXRoIGQ9Ik05Ljc4MyAxNy41OTdINy4zOThjLTEuMTY4IDAtMi4wOTItLjI5Ny0yLjc3My0uODktLjY4LS41OTMtMS4wMi0xLjQ2Mi0xLjAyLTIuNjA2di0xLjM0NmMwLTEuMDE4LS4yMjctMS43NS0uNjc4LTIuMTk1LS40NTItLjQ0Ni0xLjIzMi0uNjY5LTIuMzQtLjY2OUgwVjcuNzA1aC41ODdjMS4xMDggMCAxLjg4OC0uMjIyIDIuMzQtLjY2OC40NTEtLjQ0Ni42NzctMS4xNzcuNjc3LTIuMTk1VjMuNDk2YzAtMS4xNDQuMzQtMi4wMTMgMS4wMjEtMi42MDZDNS4zMDUuMjk3IDYuMjMgMCA3LjM5OCAwaDIuMzg1djEuOTg3aC0uOTg1Yy0uMzYxIDAtLjY4OC4wMjctLjk4LjA4MmExLjcxOSAxLjcxOSAwIDAgMC0uNzM2LjMwN2MtLjIwNS4xNTYtLjM1OC4zODQtLjQ2LjY4Mi0uMTAzLjI5OC0uMTU0LjY4Mi0uMTU0IDEuMTUxVjUuMjNjMCAuODY3LS4yNDkgMS41ODYtLjc0NSAyLjE1NS0uNDk3LjU2OS0xLjE1OCAxLjAwNC0xLjk4MyAxLjMwNXYuMjE3Yy44MjUuMyAxLjQ4Ni43MzYgMS45ODMgMS4zMDUuNDk2LjU3Ljc0NSAxLjI4Ny43NDUgMi4xNTR2MS4wMjFjMCAuNDcuMDUxLjg1NC4xNTMgMS4xNTIuMTAzLjI5OC4yNTYuNTI1LjQ2MS42ODIuMTkzLjE1Ny40MzcuMjYuNzMyLjMxMi4yOTUuMDUuNjIzLjA3Ni45ODQuMDc2aC45ODVabTE0LjMxNC03LjcwNmgtLjU4OGMtMS4xMDggMC0xLjg4OC4yMjMtMi4zNC42NjktLjQ1LjQ0NS0uNjc3IDEuMTc3LS42NzcgMi4xOTVWMTQuMWMwIDEuMTQ0LS4zNCAyLjAxMy0xLjAyIDIuNjA2LS42OC41OTMtMS42MDUuODktMi43NzQuODloLTIuMzg0di0xLjk4OGguOTg0Yy4zNjIgMCAuNjg4LS4wMjcuOTgtLjA4LjI5Mi0uMDU1LjUzOC0uMTU3LjczNy0uMzA4LjIwNC0uMTU3LjM1OC0uMzg0LjQ2LS42ODIuMTAzLS4yOTguMTU0LS42ODIuMTU0LTEuMTUydi0xLjAyYzAtLjg2OC4yNDgtMS41ODYuNzQ1LTIuMTU1LjQ5Ny0uNTcgMS4xNTgtMS4wMDQgMS45ODMtMS4zMDV2LS4yMTdjLS44MjUtLjMwMS0xLjQ4Ni0uNzM2LTEuOTgzLTEuMzA1LS40OTctLjU3LS43NDUtMS4yODgtLjc0NS0yLjE1NXYtMS4wMmMwLS40Ny0uMDUxLS44NTQtLjE1NC0xLjE1Mi0uMTAyLS4yOTgtLjI1Ni0uNTI2LS40Ni0uNjgyYTEuNzE5IDEuNzE5IDAgMCAwLS43MzctLjMwNyA1LjM5NSA1LjM5NSAwIDAgMC0uOTgtLjA4MmgtLjk4NFYwaDIuMzg0YzEuMTY5IDAgMi4wOTMuMjk3IDIuNzc0Ljg5LjY4LjU5MyAxLjAyIDEuNDYyIDEuMDIgMi42MDZ2MS4zNDZjMCAxLjAxOC4yMjYgMS43NS42NzggMi4xOTUuNDUxLjQ0NiAxLjIzMS42NjggMi4zNC42NjhoLjU4N3oiIGZpbGw9IiNmZmYiLz48L3N2Zz4=)](https://thanks.dev/soywod)
+[![PayPal](https://img.shields.io/badge/-PayPal-0079c1?logo=PayPal&logoColor=ffffff)](https://www.paypal.com/paypalme/soywod)

--- a/README-ES.md
+++ b/README-ES.md
@@ -1,0 +1,429 @@
+<div align="center">
+  <img src="./logo.svg" alt="Logo" width="128" height="128" />
+  <h1>📫 Himalaya</h1>
+  <p>CLI para gestionar correos</p>
+  <p>
+    <a href="https://github.com/pimalaya/himalaya/releases/latest"><img alt="Release" src="https://img.shields.io/github/v/release/pimalaya/himalaya?color=success"/></a>
+    <a href="https://repology.org/project/himalaya/versions"><img alt="Repology" src="https://img.shields.io/repology/repositories/himalaya?color=success"></a>
+    <a href="https://matrix.to/#/#pimalaya:matrix.org"><img alt="Matrix" src="https://img.shields.io/badge/chat-%23pimalaya-blue?style=flat&logo=matrix&logoColor=white"/></a>
+    <a href="https://fosstodon.org/@pimalaya"><img alt="Mastodon" src="https://img.shields.io/badge/news-%40pimalaya-blue?style=flat&logo=mastodon&logoColor=white"/></a>
+  </p>
+  <p>
+    <strong>Idiomas / Languages:</strong>
+    <a href="README.md">English</a> ·
+    <a href="README-ZH.md">中文</a> ·
+    <a href="README-ES.md">Español</a> ·
+    <a href="README-FR.md">Français</a> ·
+    <a href="README-PT.md">Português</a> ·
+    <a href="README-RU.md">Русский</a> ·
+    <a href="README-DE.md">Deutsch</a>
+  </p>
+</div>
+
+```
+himalaya envelopes list --account posteo -m Archives.FOSS --page 2
+```
+
+![screenshot](./screenshot.jpeg)
+
+> [!IMPORTANT]
+> Este README documenta Himalaya v2, que **aún no se ha publicado**. Si usas v1 (`himalaya v1.2.0` o anterior), consulta el [README de v1.2.0](https://github.com/pimalaya/himalaya/blob/v1.2.0/README.md). La guía [MIGRATION.md](./MIGRATION.md) explica a los usuarios de v1 los cambios incompatibles.
+
+## Tabla de contenidos
+
+- [Características](#features)
+- [Instalación](#installation)
+  - [Binario precompilado](#pre-built-binary)
+  - [Cargo](#cargo)
+  - [Arch Linux](#arch-linux)
+  - [Homebrew](#homebrew)
+  - [Scoop](#scoop)
+  - [Fedora Linux/CentOS/RHEL](#fedora-linuxcentosrhel)
+  - [Nix](#nix)
+  - [Fuentes](#sources)
+- [Configuración](#configuration)
+- [Uso](#usage)
+  - [API compartida](#shared-api)
+  - [APIs específicas por protocolo](#protocol-specific-apis)
+  - [Redactar mensajes](#composing-messages)
+  - [Leer mensajes](#reading-messages)
+  - [Reutilizar sesiones](#re-using-sessions)
+- [Interfaces](#interfaces)
+- [Preguntas frecuentes](#faq)
+- [Redes sociales](#social)
+- [Patrocinio](#sponsoring)
+
+## Características
+
+- **API compartida** que mapea `mailboxes`, `envelopes`, `flags`, `messages` y `attachments` al backend activo
+- **APIs específicas por protocolo** que exponen la superficie completa de cada backend (`himalaya imap/smtp/maildir/jmap…`)
+- Soporte **IMAP** <sup>[rfc9051](https://www.iana.org/go/rfc9051)</sup> (requiere la feature `imap`)
+- Soporte **JMAP** <sup>[rfc8620](https://www.iana.org/go/rfc8620), [rfc8621](https://www.iana.org/go/rfc8621)</sup> (requiere la feature `jmap`)
+- Soporte **Maildir** (requiere la feature `maildir`)
+- Backend **SMTP** <sup>[rfc5321](https://www.iana.org/go/rfc5321)</sup> (requiere la feature `smtp`)
+- Soporte **TLS**:
+  - [native-tls](https://crates.io/crates/native-tls) (requiere la feature `native-tls`)
+  - [rustls](https://crates.io/crates/rustls):
+    - Proveedor criptográfico AWS-LC (requiere la feature `rustls-aws`)
+    - Proveedor criptográfico Ring (requiere la feature `rustls-ring`)
+- Soporte **SASL**: anonymous, login, plain, oauthbearer, xoauth2, scram-sha-256
+- Asistente de **descubrimiento de proveedor** impulsado por [io-discovery](https://github.com/pimalaya/io-discovery): Thunderbird Autoconfiguration, PACC y consultas SRV RFC 6186
+- Configuración **TOML** con soporte multi-cuenta
+- Salida **JSON** mediante `--json`
+
+*Himalaya CLI está escrito en [Rust](https://www.rust-lang.org/) y usa [cargo features](https://doc.rust-lang.org/cargo/reference/features.html) para activar o desactivar funcionalidades. Las features por defecto están en la sección `features` del [`Cargo.toml`](./Cargo.toml#L18) o en [docs.rs](https://docs.rs/crate/himalaya/latest/features).*
+
+## Instalación
+
+### Binario precompilado
+
+Himalaya CLI puede instalarse con el instalador `install.sh`:
+
+*Como root:*
+
+```
+curl -sSL https://raw.githubusercontent.com/pimalaya/himalaya/master/install.sh | sudo sh
+```
+
+*Como usuario normal:*
+
+```
+curl -sSL https://raw.githubusercontent.com/pimalaya/himalaya/master/install.sh | PREFIX=~/.local sh
+```
+
+Estos comandos instalan el último binario de la sección [releases](https://github.com/pimalaya/himalaya/releases) de GitHub.
+
+Si necesitas una versión más reciente que el último release, revisa el flujo de trabajo [releases](https://github.com/pimalaya/himalaya/actions/workflows/releases.yml) en GitHub y busca la sección *Artifacts*. Encontrarás un binario precompilado para tu SO. Esos binarios se construyen desde la rama `master`.
+
+*Dichos binarios se compilan con las cargo features por defecto. Si necesitas más features, usa otro método de instalación.*
+
+### Cargo
+
+Himalaya CLI puede instalarse con [cargo](https://doc.rust-lang.org/cargo/):
+
+```
+cargo install himalaya --locked
+```
+
+Solo con soporte IMAP:
+
+```
+cargo install himalaya --locked --no-default-features --features imap
+```
+
+También puedes usar el repositorio git para una versión más actualizada (pero menos estable):
+
+```
+cargo install --locked --git https://github.com/pimalaya/himalaya.git
+```
+
+### Arch Linux
+
+Himalaya CLI puede instalarse en [Arch Linux](https://archlinux.org/) con el repositorio comunitario:
+
+```
+pacman -S himalaya
+```
+
+o con el [repositorio de usuarios](https://aur.archlinux.org/):
+
+```
+git clone https://aur.archlinux.org/himalaya-git.git
+cd himalaya-git
+makepkg -isc
+```
+
+Si usas [yay](https://github.com/Jguer/yay), es aún más sencillo:
+
+```
+yay -S himalaya-git
+```
+
+### Homebrew
+
+Himalaya CLI puede instalarse con [Homebrew](https://brew.sh/):
+
+```
+brew install himalaya
+```
+
+Nota: las cargo features no son compatibles con brew. Si necesitas otro conjunto de features, usa otro método de instalación.
+
+### Scoop
+
+Himalaya CLI puede instalarse con [Scoop](https://scoop.sh/):
+
+```
+scoop install himalaya
+```
+
+### Fedora Linux/CentOS/RHEL
+
+Himalaya CLI puede instalarse en [Fedora Linux](https://fedoraproject.org/)/CentOS/RHEL mediante el repositorio [COPR](https://copr.fedorainfracloud.org/coprs/atim/himalaya/):
+
+```
+dnf copr enable atim/himalaya
+dnf install himalaya
+```
+
+### Nix
+
+Himalaya CLI puede instalarse con [Nix](https://serokell.io/blog/what-is-nix):
+
+```
+nix-env -i himalaya
+```
+
+También puedes usar el repositorio git para una versión más actualizada (pero menos estable):
+
+```
+nix-env -if https://github.com/pimalaya/himalaya/archive/master.tar.gz
+```
+
+*O, desde el árbol de fuentes clonado:*
+
+```
+nix-env -if .
+```
+
+Si tienes la feature [Flakes](https://nixos.wiki/wiki/Flakes) activada:
+
+```
+nix profile install github:pimalaya/himalaya
+```
+
+*O, desde el árbol de fuentes clonado:*
+
+```
+nix profile install
+```
+
+*También puedes ejecutar Himalaya sin instalarlo:*
+
+```
+nix run github:pimalaya/himalaya
+```
+
+### Fuentes
+
+```
+git clone https://github.com/pimalaya/himalaya
+cd himalaya
+nix develop --command cargo build --release
+```
+
+*Los binarios están en la carpeta `target/release`.*
+
+## Configuración
+
+Ejecuta `himalaya`. Si no hay archivo de configuración, el asistente pide nombre de cuenta y dirección de correo, ejecuta el [descubrimiento de proveedor](https://github.com/pimalaya/io-discovery) (PACC → Thunderbird Autoconfiguration → RFC 6186 SRV), rellena las preguntas IMAP/SMTP (o JMAP) con los valores descubiertos y escribe el resultado en disco.
+
+Las cuentas pueden (re)configurarse después con `himalaya account configure <name>`. En este modo el asistente omite el descubrimiento: reutiliza los valores existentes como valores por defecto de las preguntas.
+
+También puedes escribir la configuración a mano:
+
+- Copia el [./config.sample.toml](./config.sample.toml) documentado
+- Pégalo en uno de:
+  - `$XDG_CONFIG_HOME/himalaya/config.toml`
+  - `$HOME/.config/himalaya/config.toml`
+  - `$HOME/.himalayarc`
+- Comenta o descomenta las opciones que quieras
+
+…o pasa `-c <PATH>` / establece `HIMALAYA_CONFIG=<PATH>`. Puedes pasar varias rutas a la vez, separadas por `:`; la primera es la base y el resto se fusionan en profundidad encima.
+
+## Uso
+
+### API compartida
+
+Los comandos independientes del backend operan sobre el primer backend configurado de la cuenta, o el seleccionado con `-b/--backend`:
+
+```
+himalaya mailboxes list
+himalaya envelopes list -m INBOX --page 2
+himalaya envelopes search from alice and after 2026-01-01 order by date desc
+himalaya flags add -m INBOX --flag seen 1:3,5
+himalaya messages copy --from INBOX --to Archives 42
+himalaya attachments download -m INBOX 42
+```
+
+Cuando el alias `inbox` está configurado bajo `[mailbox.alias]`, `-m/--mailbox` pasa a ser opcional: los comandos compartidos usan ese id por defecto. Con `[mailbox.alias] inbox = "INBOX"`, las llamadas anteriores se acortan a `envelopes list --page 2`, `flags add --flag seen 1:3,5`, etc.
+
+`envelopes list` es paginación simple, ordenada por fecha descendente. Para filtrar u ordenar, usa `envelopes search` con una consulta final que cubre condiciones `date`, `after`, `from`, `to`, `subject`, `body`, `flag` (combinadas con `and`, `or`, `not`, agrupadas con paréntesis) y una cadena de orden `order by date|from|to|subject [asc|desc]`. Las cláusulas de fecha apuntan a la cabecera `Date:` (fecha de envío) en todos los backends.
+
+La superficie compartida es un subconjunto estricto del mínimo común denominador entre IMAP, JMAP y Maildir. Las operaciones que no se generalizan (roles de buzón, flags de atributos, consultas específicas de JMAP…) viven bajo los subcomandos específicos del protocolo.
+
+### APIs específicas por protocolo
+
+Cada backend expone su API nativa completa bajo su propio subgrupo:
+
+```
+himalaya imap mailboxes select INBOX
+himalaya imap mailboxes status INBOX
+himalaya imap mailboxes subscribe INBOX
+
+himalaya jmap mailboxes query --role drafts
+himalaya jmap identity get
+himalaya jmap vacation get
+
+himalaya maildir create Archives
+himalaya maildir messages save -m ~/Mail/example/Archives < message.eml
+
+himalaya smtp messages send < message.eml
+```
+
+La opción `-b/--backend` solo la consumen los comandos compartidos; los subcomandos de protocolo siempre usan su propio backend.
+
+### Redactar mensajes
+
+Los comandos integrados `messages compose` / `reply` / `forward` cubren casos simples mediante flags de la CLI:
+
+```
+himalaya messages compose --from me@example.org --to you@example.org \
+    --subject "Hello" --body "Hi!" --send
+```
+
+Para composición más rica (MIME multiparte, directivas MML, firma/cifrado, flujos con editor…), configura un compositor definido por el usuario en `[message.composer.*]` e invócalo con las variantes `-with`. Por ejemplo, con [`mml`](https://github.com/pimalaya/mml):
+
+```toml
+[message.composer.mml]
+command = "mml compose"
+default = true
+```
+
+```
+himalaya messages compose-with
+himalaya messages reply-with -m INBOX 42 --send
+himalaya messages forward-with -m INBOX 42 --send
+himalaya messages mailto 'mailto:bob@example.org?subject=Hi&body=Hello'
+```
+
+`messages mailto <URI>` analiza una URI `mailto:` RFC 6068 (lista de destinatarios en la ruta, parámetros de consulta `to` / `cc` / `bcc` / `subject` / `body`), construye un borrador RFC 5322 con esas cabeceras prellenadas y lo envía por stdin al compositor nombrado (o por defecto) para editar. La salida del compositor se enruta con `--save` / `--send` como las otras variantes `-with`. Útil como manejador de escritorio `mailto:`.
+
+### Leer mensajes
+
+El comando integrado `messages read` renderiza un mensaje con el formateador por defecto de himalaya. Para renderizado personalizado, declara un lector en `[message.reader.*]` y llama a `read-with`:
+
+```toml
+[message.reader.mml]
+command = "mml read"
+default = true
+```
+
+```
+himalaya messages read-with -m INBOX 42
+```
+
+### Reutilizar sesiones
+
+Cada invocación abre por defecto una sesión TCP+TLS+SASL nueva. Para amortizar el handshake en muchos comandos, combina himalaya con [`sirup`](https://github.com/pimalaya/sirup): `sirup` expone una sesión IMAP/SMTP preautenticada por un socket Unix, y himalaya puede apuntar su `imap.server` / `smtp.server` a ese socket.
+
+## Interfaces
+
+Estas interfaces se construyen sobre Himalaya CLI para mejorar la experiencia de usuario:
+
+- [pimalaya/himalaya-tui](https://github.com/pimalaya/himalaya-tui): TUI oficial (en desarrollo activo)
+- [pimalaya/himalaya-vim](https://github.com/pimalaya/himalaya-vim): complemento Vim
+- [dantecatalfamo/himalaya-emacs](https://github.com/dantecatalfamo/himalaya-emacs): complemento Emacs
+- [jns/himalaya](https://www.raycast.com/jns/himalaya): extensión Raycast
+- [openclaw/openclaw](https://github.com/openclaw/openclaw/blob/main/skills/himalaya/SKILL.md): SKILL OpenClaw
+- [parisni/dfzf](https://github.com/parisni/dfzf): integración dfzf
+
+## Preguntas frecuentes
+
+<details>
+  <summary>¿En qué se diferencia de aerc, mutt o alpine?</summary>
+
+  aerc, mutt y alpine pueden clasificarse como interfaces de usuario en terminal (TUI). Al ejecutar el programa, la terminal queda bloqueada en un bucle de eventos e interactúas con el correo mediante atajos de teclado.
+
+  Himalaya es una interfaz de línea de comandos (CLI). No hay bucle de eventos: interactúas con el correo mediante comandos de shell, de forma sin estado.
+
+  Una TUI dedicada ([himalaya-tui](https://github.com/pimalaya/himalaya-tui)) está en desarrollo activo sobre las mismas bibliotecas Pimalaya.
+</details>
+
+<details>
+  <summary>¿Cómo se resuelven los secretos?</summary>
+
+  Cada campo `*.passwd` / `*.password` / `*.token` acepta un literal en bruto o un comando shell que imprime el secreto en stdout. La forma en bruto es cómoda para pruebas pero no debe usarse en producción:
+
+  ```toml
+  imap.sasl.plain.passwd.raw = "***"
+  imap.sasl.plain.passwd.command = "pass show example"
+  imap.sasl.plain.passwd.command = ["pass", "show", "example"]
+  ```
+
+  El soporte nativo del llavero se eliminó en v2. Usa [pimalaya/mimosa](https://github.com/pimalaya/mimosa) (o `pass`, `secret-tool`, `gopass`…) como `command`.
+</details>
+
+<details>
+  <summary>¿Cómo se gestiona OAuth 2.0?</summary>
+
+  v2 no incluye flujos OAuth. Usa [pimalaya/ortie](https://github.com/pimalaya/ortie) (u otro intermediario de tokens) para obtener un token de acceso y conéctalo como `command` que devuelve el token en stdout. Para JMAP, apunta `jmap.auth.bearer.token.command` al intermediario; para IMAP/SMTP, enruta el bearer por un mecanismo SASL que consuma una contraseña obtenida por comando.
+</details>
+
+<details>
+  <summary>¿Cómo descubre el asistente las configuraciones IMAP/SMTP/JMAP?</summary>
+
+  El asistente ejecuta tres mecanismos de descubrimiento en serie sobre el dominio del correo; gana el primer resultado no vacío:
+
+  1. **PACC** <sup>[draft-ietf-mailmaint-pacc-02](https://datatracker.ietf.org/doc/html/draft-ietf-mailmaint-pacc-02)</sup>: JSON well-known, verificado por digest frente al registro TXT `_ua-auto-config`.
+  2. **Thunderbird Autoconfiguration**: consultas ISP main / well-known / ISPDB, reintento basado en MX, luego la redirección TXT `mailconf=<URL>`.
+  3. **RFC 6186 SRV**: consultas `_imap._tcp`, `_imaps._tcp`, `_submission._tcp` ensambladas en un único informe.
+
+  Consulta [io-discovery](https://github.com/pimalaya/io-discovery) para la cadena completa.
+</details>
+
+<details>
+  <summary>¿Cómo depurar Himalaya CLI?</summary>
+
+  Usa `--log-level <level>` (alias `--log`) donde `<level>` es uno de `off`, `error`, `warn`, `info`, `debug`, `trace`:
+
+  ```
+  himalaya --log trace mailboxes list
+  ```
+
+  La variable de entorno `RUST_LOG` se consulta cuando no se pasa `--log`, y admite filtros por objetivo (véase la [documentación de `env_logger`](https://docs.rs/env_logger/latest/env_logger/#enabling-logging)). `RUST_BACKTRACE=1` activa trazas de error completas.
+
+  Los registros se escriben en `stderr`, así que pueden redirigirse fácilmente a un archivo:
+
+  ```
+  himalaya --log trace mailboxes list 2>/tmp/himalaya.log
+  ```
+
+  También puedes enviar los registros directamente a un archivo con `--log-file <path>`:
+
+  ```
+  himalaya --log trace --log-file /tmp/himalaya.log mailboxes list
+  ```
+</details>
+
+<details>
+  <summary>¿Cómo desactivar la salida en color?</summary>
+
+  Establece `NO_COLOR=1` en tu entorno.
+</details>
+
+## Redes sociales
+
+- Chat en [Matrix](https://matrix.to/#/#pimalaya:matrix.org)
+- Noticias en [Mastodon](https://fosstodon.org/@pimalaya) o [RSS](https://fosstodon.org/@pimalaya.rss)
+- Correo a [pimalaya.org@posteo.net](mailto:pimalaya.org@posteo.net)
+
+## Patrocinio
+
+[![nlnet](https://nlnet.nl/logo/banner-160x60.png)](https://nlnet.nl/)
+
+Agradecimiento especial a la [fundación NLnet](https://nlnet.nl/) y la [Comisión Europea](https://www.ngi.eu/), que han financiado el proyecto durante años:
+
+- 2022 → 2023: [NGI Assure](https://nlnet.nl/project/Himalaya/)
+- 2023 → 2024: [NGI Zero Entrust](https://nlnet.nl/project/Pimalaya/)
+- 2024 → 2026: [NGI Zero Core](https://nlnet.nl/project/Pimalaya-PIM/)
+- *2027 en preparación…*
+
+Si valoras el proyecto, puedes donar mediante uno de estos proveedores:
+
+[![GitHub](https://img.shields.io/badge/-GitHub%20Sponsors-fafbfc?logo=GitHub%20Sponsors)](https://github.com/sponsors/soywod)
+[![Ko-fi](https://img.shields.io/badge/-Ko--fi-ff5e5a?logo=Ko-fi&logoColor=ffffff)](https://ko-fi.com/soywod)
+[![Buy Me a Coffee](https://img.shields.io/badge/-Buy%20Me%20a%20Coffee-ffdd00?logo=Buy%20Me%20A%20Coffee&logoColor=000000)](https://www.buymeacoffee.com/soywod)
+[![Liberapay](https://img.shields.io/badge/-Liberapay-f6c915?logo=Liberapay&logoColor=222222)](https://liberapay.com/soywod)
+[![thanks.dev](https://img.shields.io/badge/-thanks.dev-000000?logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQuMDk3IiBoZWlnaHQ9IjE3LjU5NyIgY2xhc3M9InctMzYgbWwtMiBsZzpteC0wIHByaW50Om14LTAgcHJpbnQ6aW52ZXJ0IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxwYXRoIGQ9Ik05Ljc4MyAxNy41OTdINy4zOThjLTEuMTY4IDAtMi4wOTItLjI5Ny0yLjc3My0uODktLjY4LS41OTMtMS4wMi0xLjQ2Mi0xLjAyLTIuNjA2di0xLjM0NmMwLTEuMDE4LS4yMjctMS43NS0uNjc4LTIuMTk1LS40NTItLjQ0Ni0xLjIzMi0uNjY5LTIuMzQtLjY2OUgwVjcuNzA1aC41ODdjMS4xMDggMCAxLjg4OC0uMjIyIDIuMzQtLjY2OC40NTEtLjQ0Ni42NzctMS4xNzcuNjc3LTIuMTk1VjMuNDk2YzAtMS4xNDQuMzQtMi4wMTMgMS4wMjEtMi42MDZDNS4zMDUuMjk3IDYuMjMgMCA3LjM5OCAwaDIuMzg1djEuOTg3aC0uOTg1Yy0uMzYxIDAtLjY4OC4wMjctLjk4LjA4MmExLjcxOSAxLjcxOSAwIDAgMC0uNzM2LjMwN2MtLjIwNS4xNTYtLjM1OC4zODQtLjQ2LjY4Mi0uMTAzLjI5OC0uMTU0LjY4Mi0uMTU0IDEuMTUxVjUuMjNjMCAuODY3LS4yNDkgMS41ODYtLjc0NSAyLjE1NS0uNDk3LjU2OS0xLjE1OCAxLjAwNC0xLjk4MyAxLjMwNXYuMjE3Yy44MjUuMyAxLjQ4Ni43MzYgMS45ODMgMS4zMDUuNDk2LjU3Ljc0NSAxLjI4Ny43NDUgMi4xNTR2MS4wMjFjMCAuNDcuMDUxLjg1NC4xNTMgMS4xNTIuMTAzLjI5OC4yNTYuNTI1LjQ2MS42ODIuMTkzLjE1Ny40MzcuMjYuNzMyLjMxMi4yOTUuMDUuNjIzLjA3Ni45ODQuMDc2aC45ODVabTE0LjMxNC03LjcwNmgtLjU4OGMtMS4xMDggMC0xLjg4OC4yMjMtMi4zNC42NjktLjQ1LjQ0NS0uNjc3IDEuMTc3LS42NzcgMi4xOTVWMTQuMWMwIDEuMTQ0LS4zNCAyLjAxMy0xLjAyIDIuNjA2LS42OC41OTMtMS42MDUuODktMi43NzQuODloLTIuMzg0di0xLjk4OGguOTg0Yy4zNjIgMCAuNjg4LS4wMjcuOTgtLjA4LjI5Mi0uMDU1LjUzOC0uMTU3LjczNy0uMzA4LjIwNC0uMTU3LjM1OC0uMzg0LjQ2LS42ODIuMTAzLS4yOTguMTU0LS42ODIuMTU0LTEuMTUydi0xLjAyYzAtLjg2OC4yNDgtMS41ODYuNzQ1LTIuMTU1LjQ5Ny0uNTcgMS4xNTgtMS4wMDQgMS45ODMtMS4zMDV2LS4yMTdjLS44MjUtLjMwMS0xLjQ4Ni0uNzM2LTEuOTgzLTEuMzA1LS40OTctLjU3LS43NDUtMS4yODgtLjc0NS0yLjE1NXYtMS4wMmMwLS40Ny0uMDUxLS44NTQtLjE1NC0xLjE1Mi0uMTAyLS4yOTgtLjI1Ni0uNTI2LS40Ni0uNjgyYTEuNzE5IDEuNzE5IDAgMCAwLS43MzctLjMwNyA1LjM5NSA1LjM5NSAwIDAgMC0uOTgtLjA4MmgtLjk4NFYwaDIuMzg0YzEuMTY5IDAgMi4wOTMuMjk3IDIuNzc0Ljg5LjY4LjU5MyAxLjAyIDEuNDYyIDEuMDIgMi42MDZ2MS4zNDZjMCAxLjAxOC4yMjYgMS43NS42NzggMi4xOTUuNDUxLjQ0NiAxLjIzMS42NjggMi4zNC42NjhoLjU4N3oiIGZpbGw9IiNmZmYiLz48L3N2Zz4=)](https://thanks.dev/soywod)
+[![PayPal](https://img.shields.io/badge/-PayPal-0079c1?logo=PayPal&logoColor=ffffff)](https://www.paypal.com/paypalme/soywod)

--- a/README-FR.md
+++ b/README-FR.md
@@ -1,0 +1,429 @@
+<div align="center">
+  <img src="./logo.svg" alt="Logo" width="128" height="128" />
+  <h1>📫 Himalaya</h1>
+  <p>CLI pour gérer les e-mails</p>
+  <p>
+    <a href="https://github.com/pimalaya/himalaya/releases/latest"><img alt="Release" src="https://img.shields.io/github/v/release/pimalaya/himalaya?color=success"/></a>
+    <a href="https://repology.org/project/himalaya/versions"><img alt="Repology" src="https://img.shields.io/repology/repositories/himalaya?color=success"></a>
+    <a href="https://matrix.to/#/#pimalaya:matrix.org"><img alt="Matrix" src="https://img.shields.io/badge/chat-%23pimalaya-blue?style=flat&logo=matrix&logoColor=white"/></a>
+    <a href="https://fosstodon.org/@pimalaya"><img alt="Mastodon" src="https://img.shields.io/badge/news-%40pimalaya-blue?style=flat&logo=mastodon&logoColor=white"/></a>
+  </p>
+  <p>
+    <strong>Langues / Languages:</strong>
+    <a href="README.md">English</a> ·
+    <a href="README-ZH.md">中文</a> ·
+    <a href="README-ES.md">Español</a> ·
+    <a href="README-FR.md">Français</a> ·
+    <a href="README-PT.md">Português</a> ·
+    <a href="README-RU.md">Русский</a> ·
+    <a href="README-DE.md">Deutsch</a>
+  </p>
+</div>
+
+```
+himalaya envelopes list --account posteo -m Archives.FOSS --page 2
+```
+
+![screenshot](./screenshot.jpeg)
+
+> [!IMPORTANT]
+> Ce README documente Himalaya v2, qui **n’est pas encore publié**. Si vous utilisez v1 (`himalaya v1.2.0` ou antérieur), consultez le [README v1.2.0](https://github.com/pimalaya/himalaya/blob/v1.2.0/README.md). Le guide [MIGRATION.md](./MIGRATION.md) accompagne les utilisateurs v1 à travers les changements incompatibles.
+
+## Table des matières
+
+- [Fonctionnalités](#features)
+- [Installation](#installation)
+  - [Binaire précompilé](#pre-built-binary)
+  - [Cargo](#cargo)
+  - [Arch Linux](#arch-linux)
+  - [Homebrew](#homebrew)
+  - [Scoop](#scoop)
+  - [Fedora Linux/CentOS/RHEL](#fedora-linuxcentosrhel)
+  - [Nix](#nix)
+  - [Sources](#sources)
+- [Configuration](#configuration)
+- [Utilisation](#usage)
+  - [API partagée](#shared-api)
+  - [APIs spécifiques aux protocoles](#protocol-specific-apis)
+  - [Rédiger des messages](#composing-messages)
+  - [Lire des messages](#reading-messages)
+  - [Réutiliser les sessions](#re-using-sessions)
+- [Interfaces](#interfaces)
+- [FAQ](#faq)
+- [Réseaux sociaux](#social)
+- [Parrainage](#sponsoring)
+
+## Fonctionnalités
+
+- **API partagée** qui mappe `mailboxes`, `envelopes`, `flags`, `messages` et `attachments` vers le backend actif
+- **APIs spécifiques aux protocoles** exposant la surface complète de chaque backend (`himalaya imap/smtp/maildir/jmap…`)
+- Prise en charge **IMAP** <sup>[rfc9051](https://www.iana.org/go/rfc9051)</sup> (nécessite la feature `imap`)
+- Prise en charge **JMAP** <sup>[rfc8620](https://www.iana.org/go/rfc8620), [rfc8621](https://www.iana.org/go/rfc8621)</sup> (nécessite la feature `jmap`)
+- Prise en charge **Maildir** (nécessite la feature `maildir`)
+- Backend **SMTP** <sup>[rfc5321](https://www.iana.org/go/rfc5321)</sup> (nécessite la feature `smtp`)
+- Prise en charge **TLS** :
+  - [native-tls](https://crates.io/crates/native-tls) (nécessite la feature `native-tls`)
+  - [rustls](https://crates.io/crates/rustls) :
+    - Fournisseur crypto AWS-LC (nécessite la feature `rustls-aws`)
+    - Fournisseur crypto Ring (nécessite la feature `rustls-ring`)
+- Prise en charge **SASL** : anonymous, login, plain, oauthbearer, xoauth2, scram-sha-256
+- Assistant de **découverte de fournisseur** alimenté par [io-discovery](https://github.com/pimalaya/io-discovery) : Thunderbird Autoconfiguration, PACC et recherches SRV RFC 6186
+- Configuration **TOML** avec prise en charge multi-comptes
+- Sortie **JSON** via `--json`
+
+*Himalaya CLI est écrit en [Rust](https://www.rust-lang.org/) et s’appuie sur les [cargo features](https://doc.rust-lang.org/cargo/reference/features.html) pour activer ou désactiver des fonctionnalités. Les features par défaut se trouvent dans la section `features` du [`Cargo.toml`](./Cargo.toml#L18), ou sur [docs.rs](https://docs.rs/crate/himalaya/latest/features).*
+
+## Installation
+
+### Binaire précompilé
+
+Himalaya CLI peut être installé avec l’installateur `install.sh` :
+
+*En tant que root :*
+
+```
+curl -sSL https://raw.githubusercontent.com/pimalaya/himalaya/master/install.sh | sudo sh
+```
+
+*En tant qu’utilisateur normal :*
+
+```
+curl -sSL https://raw.githubusercontent.com/pimalaya/himalaya/master/install.sh | PREFIX=~/.local sh
+```
+
+Ces commandes installent le dernier binaire depuis la section [releases](https://github.com/pimalaya/himalaya/releases) de GitHub.
+
+Si vous voulez une version plus récente que la dernière release, consultez le workflow GitHub [releases](https://github.com/pimalaya/himalaya/actions/workflows/releases.yml) et cherchez la section *Artifacts*. Vous y trouverez un binaire précompilé pour votre OS. Ces binaires sont construits depuis la branche `master`.
+
+*De tels binaires sont compilés avec les cargo features par défaut. Si vous avez besoin de plus de features, utilisez une autre méthode d’installation.*
+
+### Cargo
+
+Himalaya CLI peut être installé avec [cargo](https://doc.rust-lang.org/cargo/) :
+
+```
+cargo install himalaya --locked
+```
+
+Avec uniquement la prise en charge IMAP :
+
+```
+cargo install himalaya --locked --no-default-features --features imap
+```
+
+Vous pouvez aussi utiliser le dépôt git pour une version plus à jour (mais moins stable) :
+
+```
+cargo install --locked --git https://github.com/pimalaya/himalaya.git
+```
+
+### Arch Linux
+
+Himalaya CLI peut être installé sur [Arch Linux](https://archlinux.org/) via le dépôt communautaire :
+
+```
+pacman -S himalaya
+```
+
+ou le [dépôt utilisateur](https://aur.archlinux.org/) :
+
+```
+git clone https://aur.archlinux.org/himalaya-git.git
+cd himalaya-git
+makepkg -isc
+```
+
+Si vous utilisez [yay](https://github.com/Jguer/yay), c’est encore plus simple :
+
+```
+yay -S himalaya-git
+```
+
+### Homebrew
+
+Himalaya CLI peut être installé avec [Homebrew](https://brew.sh/) :
+
+```
+brew install himalaya
+```
+
+Note : les cargo features ne sont pas compatibles avec brew. Si vous avez besoin d’un autre ensemble de features, utilisez une autre méthode d’installation.
+
+### Scoop
+
+Himalaya CLI peut être installé avec [Scoop](https://scoop.sh/) :
+
+```
+scoop install himalaya
+```
+
+### Fedora Linux/CentOS/RHEL
+
+Himalaya CLI peut être installé sur [Fedora Linux](https://fedoraproject.org/)/CentOS/RHEL via le dépôt [COPR](https://copr.fedorainfracloud.org/coprs/atim/himalaya/) :
+
+```
+dnf copr enable atim/himalaya
+dnf install himalaya
+```
+
+### Nix
+
+Himalaya CLI peut être installé avec [Nix](https://serokell.io/blog/what-is-nix) :
+
+```
+nix-env -i himalaya
+```
+
+Vous pouvez aussi utiliser le dépôt git pour une version plus à jour (mais moins stable) :
+
+```
+nix-env -if https://github.com/pimalaya/himalaya/archive/master.tar.gz
+```
+
+*Ou, depuis l’arborescence source clonée :*
+
+```
+nix-env -if .
+```
+
+Si vous avez la feature [Flakes](https://nixos.wiki/wiki/Flakes) activée :
+
+```
+nix profile install github:pimalaya/himalaya
+```
+
+*Ou, depuis l’arborescence source clonée :*
+
+```
+nix profile install
+```
+
+*Vous pouvez aussi exécuter Himalaya sans l’installer :*
+
+```
+nix run github:pimalaya/himalaya
+```
+
+### Sources
+
+```
+git clone https://github.com/pimalaya/himalaya
+cd himalaya
+nix develop --command cargo build --release
+```
+
+*Les binaires sont disponibles sous le dossier `target/release`.*
+
+## Configuration
+
+Lancez simplement `himalaya`. Si aucun fichier de configuration n’est trouvé, l’assistant demande un nom de compte et une adresse e-mail, exécute la [découverte de fournisseur](https://github.com/pimalaya/io-discovery) (PACC → Thunderbird Autoconfiguration → RFC 6186 SRV), remplit les invites IMAP/SMTP (ou JMAP) avec les valeurs découvertes et écrit le résultat sur le disque.
+
+Les comptes peuvent être (re)configurés plus tard avec `himalaya account configure <name>`. Dans ce mode, l’assistant ignore la découverte : il réutilise les valeurs existantes comme valeurs par défaut des invites.
+
+Vous pouvez aussi écrire la configuration à la main :
+
+- Copiez le [./config.sample.toml](./config.sample.toml) documenté
+- Collez-le dans l’un des emplacements suivants :
+  - `$XDG_CONFIG_HOME/himalaya/config.toml`
+  - `$HOME/.config/himalaya/config.toml`
+  - `$HOME/.himalayarc`
+- Commentez ou décommentez les options souhaitées
+
+…ou passez `-c <PATH>` / définissez `HIMALAYA_CONFIG=<PATH>`. Plusieurs chemins peuvent être passés à la fois, séparés par `:` ; le premier sert de base et les autres sont fusionnés en profondeur par-dessus.
+
+## Utilisation
+
+### API partagée
+
+Les commandes indépendantes du backend opèrent sur le premier backend configuré du compte, ou celui sélectionné avec `-b/--backend` :
+
+```
+himalaya mailboxes list
+himalaya envelopes list -m INBOX --page 2
+himalaya envelopes search from alice and after 2026-01-01 order by date desc
+himalaya flags add -m INBOX --flag seen 1:3,5
+himalaya messages copy --from INBOX --to Archives 42
+himalaya attachments download -m INBOX 42
+```
+
+Lorsque l’alias `inbox` est configuré sous `[mailbox.alias]`, `-m/--mailbox` devient optionnel : les commandes partagées retombent sur cet id. Avec `[mailbox.alias] inbox = "INBOX"`, les appels ci-dessus se raccourcissent en `envelopes list --page 2`, `flags add --flag seen 1:3,5`, etc.
+
+`envelopes list` est une pagination simple, triée par date décroissante. Pour filtrer ou trier, utilisez `envelopes search` avec une requête finale couvrant les conditions `date`, `after`, `from`, `to`, `subject`, `body`, `flag` (combinées avec `and`, `or`, `not`, regroupées avec des parenthèses) et une chaîne de tri `order by date|from|to|subject [asc|desc]`. Les clauses de date ciblent l’en-tête `Date:` (date d’envoi) sur tous les backends.
+
+La surface partagée est un sous-ensemble strict du plus petit dénominateur commun entre IMAP, JMAP et Maildir. Les opérations qui ne se généralisent pas (rôles de boîtes, drapeaux d’attributs, requêtes spécifiques JMAP…) vivent sous les sous-commandes spécifiques au protocole.
+
+### APIs spécifiques aux protocoles
+
+Chaque backend expose son API native complète sous son propre sous-groupe :
+
+```
+himalaya imap mailboxes select INBOX
+himalaya imap mailboxes status INBOX
+himalaya imap mailboxes subscribe INBOX
+
+himalaya jmap mailboxes query --role drafts
+himalaya jmap identity get
+himalaya jmap vacation get
+
+himalaya maildir create Archives
+himalaya maildir messages save -m ~/Mail/example/Archives < message.eml
+
+himalaya smtp messages send < message.eml
+```
+
+L’option `-b/--backend` n’est consommée que par les commandes partagées ; les sous-commandes de protocole utilisent toujours leur propre backend.
+
+### Rédiger des messages
+
+Les commandes intégrées `messages compose` / `reply` / `forward` couvrent les cas simples via des flags CLI :
+
+```
+himalaya messages compose --from me@example.org --to you@example.org \
+    --subject "Hello" --body "Hi!" --send
+```
+
+Pour une composition plus riche (MIME multipart, directives MML, signature/chiffrement, flux pilotés par l’éditeur…), configurez un composeur défini par l’utilisateur dans `[message.composer.*]` et invoquez-le avec les variantes `-with`. Par exemple, avec [`mml`](https://github.com/pimalaya/mml) :
+
+```toml
+[message.composer.mml]
+command = "mml compose"
+default = true
+```
+
+```
+himalaya messages compose-with
+himalaya messages reply-with -m INBOX 42 --send
+himalaya messages forward-with -m INBOX 42 --send
+himalaya messages mailto 'mailto:bob@example.org?subject=Hi&body=Hello'
+```
+
+`messages mailto <URI>` analyse une URI `mailto:` RFC 6068 (liste de destinataires dans le chemin, paramètres de requête `to` / `cc` / `bcc` / `subject` / `body`), construit un brouillon RFC 5322 avec ces en-têtes préremplis, puis l’envoie sur stdin au composeur nommé (ou par défaut) pour édition. La sortie du composeur est routée via `--save` / `--send` comme les autres variantes `-with`. Utile comme gestionnaire de bureau `mailto:`.
+
+### Lire des messages
+
+La commande intégrée `messages read` affiche un message avec le formateur par défaut de himalaya. Pour un rendu personnalisé, déclarez un lecteur dans `[message.reader.*]` et appelez `read-with` :
+
+```toml
+[message.reader.mml]
+command = "mml read"
+default = true
+```
+
+```
+himalaya messages read-with -m INBOX 42
+```
+
+### Réutiliser les sessions
+
+Chaque invocation ouvre par défaut une nouvelle session TCP+TLS+SASL. Pour amortir la poignée de main sur de nombreuses commandes, associez himalaya à [`sirup`](https://github.com/pimalaya/sirup) : `sirup` expose une session IMAP/SMTP préauthentifiée sur un socket Unix, et himalaya peut pointer son `imap.server` / `smtp.server` vers ce socket.
+
+## Interfaces
+
+Ces interfaces sont construites au-dessus de Himalaya CLI pour améliorer l’expérience utilisateur :
+
+- [pimalaya/himalaya-tui](https://github.com/pimalaya/himalaya-tui) : TUI officielle (en développement actif)
+- [pimalaya/himalaya-vim](https://github.com/pimalaya/himalaya-vim) : extension Vim
+- [dantecatalfamo/himalaya-emacs](https://github.com/dantecatalfamo/himalaya-emacs) : extension Emacs
+- [jns/himalaya](https://www.raycast.com/jns/himalaya) : extension Raycast
+- [openclaw/openclaw](https://github.com/openclaw/openclaw/blob/main/skills/himalaya/SKILL.md) : SKILL OpenClaw
+- [parisni/dfzf](https://github.com/parisni/dfzf) : intégration dfzf
+
+## FAQ
+
+<details>
+  <summary>En quoi diffère-t-il d’aerc, mutt ou alpine ?</summary>
+
+  aerc, mutt et alpine peuvent être classés comme interfaces utilisateur en terminal (TUI). À l’exécution, le terminal est verrouillé dans une boucle d’événements et vous interagissez avec vos e-mails via des raccourcis clavier.
+
+  Himalaya est une interface en ligne de commande (CLI). Il n’y a pas de boucle d’événements : vous interagissez avec vos e-mails via des commandes shell, de manière sans état.
+
+  Une TUI dédiée ([himalaya-tui](https://github.com/pimalaya/himalaya-tui)) est en développement actif sur les mêmes bibliothèques Pimalaya.
+</details>
+
+<details>
+  <summary>Comment les secrets sont-ils résolus ?</summary>
+
+  Chaque champ `*.passwd` / `*.password` / `*.token` accepte soit un littéral brut, soit une commande shell qui imprime le secret sur stdout. La forme brute est pratique pour les tests mais ne doit pas être utilisée en production :
+
+  ```toml
+  imap.sasl.plain.passwd.raw = "***"
+  imap.sasl.plain.passwd.command = "pass show example"
+  imap.sasl.plain.passwd.command = ["pass", "show", "example"]
+  ```
+
+  La prise en charge native du trousseau a été supprimée en v2. Utilisez [pimalaya/mimosa](https://github.com/pimalaya/mimosa) (ou `pass`, `secret-tool`, `gopass`…) comme `command`.
+</details>
+
+<details>
+  <summary>Comment OAuth 2.0 est-il géré ?</summary>
+
+  v2 n’embarque pas de flux OAuth. Utilisez [pimalaya/ortie](https://github.com/pimalaya/ortie) (ou tout autre courtier de jetons) pour obtenir un jeton d’accès, puis branchez-le comme `command` renvoyant le jeton sur stdout. Pour JMAP, pointez `jmap.auth.bearer.token.command` vers le courtier ; pour IMAP/SMTP, routez le bearer via un mécanisme SASL qui consomme un mot de passe issu d’une commande.
+</details>
+
+<details>
+  <summary>Comment l’assistant découvre-t-il les configs IMAP/SMTP/JMAP ?</summary>
+
+  L’assistant exécute trois mécanismes de découverte en série sur le domaine de l’adresse e-mail ; le premier résultat non vide l’emporte :
+
+  1. **PACC** <sup>[draft-ietf-mailmaint-pacc-02](https://datatracker.ietf.org/doc/html/draft-ietf-mailmaint-pacc-02)</sup> : JSON well-known, vérifié par digest contre l’enregistrement TXT `_ua-auto-config`.
+  2. **Thunderbird Autoconfiguration** : recherches ISP main / well-known / ISPDB, puis nouvelle tentative basée sur MX, puis la redirection TXT `mailconf=<URL>`.
+  3. **RFC 6186 SRV** : recherches `_imap._tcp`, `_imaps._tcp`, `_submission._tcp` assemblées en un seul rapport.
+
+  Voir [io-discovery](https://github.com/pimalaya/io-discovery) pour la chaîne complète.
+</details>
+
+<details>
+  <summary>Comment déboguer Himalaya CLI ?</summary>
+
+  Utilisez `--log-level <level>` (alias `--log`) où `<level>` est l’un de `off`, `error`, `warn`, `info`, `debug`, `trace` :
+
+  ```
+  himalaya --log trace mailboxes list
+  ```
+
+  La variable d’environnement `RUST_LOG` est consultée lorsque `--log` n’est pas passé, et prend en charge des filtres par cible (voir la [documentation `env_logger`](https://docs.rs/env_logger/latest/env_logger/#enabling-logging)). `RUST_BACKTRACE=1` active les traces d’erreur complètes.
+
+  Les journaux sont écrits sur `stderr`, ils peuvent donc être redirigés facilement vers un fichier :
+
+  ```
+  himalaya --log trace mailboxes list 2>/tmp/himalaya.log
+  ```
+
+  Vous pouvez aussi envoyer les journaux directement dans un fichier via `--log-file <path>` :
+
+  ```
+  himalaya --log trace --log-file /tmp/himalaya.log mailboxes list
+  ```
+</details>
+
+<details>
+  <summary>Comment désactiver la sortie en couleur ?</summary>
+
+  Définissez `NO_COLOR=1` dans votre environnement.
+</details>
+
+## Réseaux sociaux
+
+- Discussion sur [Matrix](https://matrix.to/#/#pimalaya:matrix.org)
+- Actualités sur [Mastodon](https://fosstodon.org/@pimalaya) ou [RSS](https://fosstodon.org/@pimalaya.rss)
+- Courriel à [pimalaya.org@posteo.net](mailto:pimalaya.org@posteo.net)
+
+## Parrainage
+
+[![nlnet](https://nlnet.nl/logo/banner-160x60.png)](https://nlnet.nl/)
+
+Remerciements particuliers à la [fondation NLnet](https://nlnet.nl/) et à la [Commission européenne](https://www.ngi.eu/) qui financent le projet depuis des années :
+
+- 2022 → 2023 : [NGI Assure](https://nlnet.nl/project/Himalaya/)
+- 2023 → 2024 : [NGI Zero Entrust](https://nlnet.nl/project/Pimalaya/)
+- 2024 → 2026 : [NGI Zero Core](https://nlnet.nl/project/Pimalaya-PIM/)
+- *2027 en préparation…*
+
+Si vous appréciez le projet, n’hésitez pas à faire un don via l’un des fournisseurs suivants :
+
+[![GitHub](https://img.shields.io/badge/-GitHub%20Sponsors-fafbfc?logo=GitHub%20Sponsors)](https://github.com/sponsors/soywod)
+[![Ko-fi](https://img.shields.io/badge/-Ko--fi-ff5e5a?logo=Ko-fi&logoColor=ffffff)](https://ko-fi.com/soywod)
+[![Buy Me a Coffee](https://img.shields.io/badge/-Buy%20Me%20a%20Coffee-ffdd00?logo=Buy%20Me%20A%20Coffee&logoColor=000000)](https://www.buymeacoffee.com/soywod)
+[![Liberapay](https://img.shields.io/badge/-Liberapay-f6c915?logo=Liberapay&logoColor=222222)](https://liberapay.com/soywod)
+[![thanks.dev](https://img.shields.io/badge/-thanks.dev-000000?logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQuMDk3IiBoZWlnaHQ9IjE3LjU5NyIgY2xhc3M9InctMzYgbWwtMiBsZzpteC0wIHByaW50Om14LTAgcHJpbnQ6aW52ZXJ0IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxwYXRoIGQ9Ik05Ljc4MyAxNy41OTdINy4zOThjLTEuMTY4IDAtMi4wOTItLjI5Ny0yLjc3My0uODktLjY4LS41OTMtMS4wMi0xLjQ2Mi0xLjAyLTIuNjA2di0xLjM0NmMwLTEuMDE4LS4yMjctMS43NS0uNjc4LTIuMTk1LS40NTItLjQ0Ni0xLjIzMi0uNjY5LTIuMzQtLjY2OUgwVjcuNzA1aC41ODdjMS4xMDggMCAxLjg4OC0uMjIyIDIuMzQtLjY2OC40NTEtLjQ0Ni42NzctMS4xNzcuNjc3LTIuMTk1VjMuNDk2YzAtMS4xNDQuMzQtMi4wMTMgMS4wMjEtMi42MDZDNS4zMDUuMjk3IDYuMjMgMCA3LjM5OCAwaDIuMzg1djEuOTg3aC0uOTg1Yy0uMzYxIDAtLjY4OC4wMjctLjk4LjA4MmExLjcxOSAxLjcxOSAwIDAgMC0uNzM2LjMwN2MtLjIwNS4xNTYtLjM1OC4zODQtLjQ2LjY4Mi0uMTAzLjI5OC0uMTU0LjY4Mi0uMTU0IDEuMTUxVjUuMjNjMCAuODY3LS4yNDkgMS41ODYtLjc0NSAyLjE1NS0uNDk3LjU2OS0xLjE1OCAxLjAwNC0xLjk4MyAxLjMwNXYuMjE3Yy44MjUuMyAxLjQ4Ni43MzYgMS45ODMgMS4zMDUuNDk2LjU3Ljc0NSAxLjI4Ny43NDUgMi4xNTR2MS4wMjFjMCAuNDcuMDUxLjg1NC4xNTMgMS4xNTIuMTAzLjI5OC4yNTYuNTI1LjQ2MS42ODIuMTkzLjE1Ny40MzcuMjYuNzMyLjMxMi4yOTUuMDUuNjIzLjA3Ni45ODQuMDc2aC45ODVabTE0LjMxNC03LjcwNmgtLjU4OGMtMS4xMDggMC0xLjg4OC4yMjMtMi4zNC42NjktLjQ1LjQ0NS0uNjc3IDEuMTc3LS42NzcgMi4xOTVWMTQuMWMwIDEuMTQ0LS4zNCAyLjAxMy0xLjAyIDIuNjA2LS42OC41OTMtMS42MDUuODktMi43NzQuODloLTIuMzg0di0xLjk4OGguOTg0Yy4zNjIgMCAuNjg4LS4wMjcuOTgtLjA4LjI5Mi0uMDU1LjUzOC0uMTU3LjczNy0uMzA4LjIwNC0uMTU3LjM1OC0uMzg0LjQ2LS42ODIuMTAzLS4yOTguMTU0LS42ODIuMTU0LTEuMTUydi0xLjAyYzAtLjg2OC4yNDgtMS41ODYuNzQ1LTIuMTU1LjQ5Ny0uNTcgMS4xNTgtMS4wMDQgMS45ODMtMS4zMDV2LS4yMTdjLS44MjUtLjMwMS0xLjQ4Ni0uNzM2LTEuOTgzLTEuMzA1LS40OTctLjU3LS43NDUtMS4yODgtLjc0NS0yLjE1NXYtMS4wMmMwLS40Ny0uMDUxLS44NTQtLjE1NC0xLjE1Mi0uMTAyLS4yOTgtLjI1Ni0uNTI2LS40Ni0uNjgyYTEuNzE5IDEuNzE5IDAgMCAwLS43MzctLjMwNyA1LjM5NSA1LjM5NSAwIDAgMC0uOTgtLjA4MmgtLjk4NFYwaDIuMzg0YzEuMTY5IDAgMi4wOTMuMjk3IDIuNzc0Ljg5LjY4LjU5MyAxLjAyIDEuNDYyIDEuMDIgMi42MDZ2MS4zNDZjMCAxLjAxOC4yMjYgMS43NS42NzggMi4xOTUuNDUxLjQ0NiAxLjIzMS42NjggMi4zNC42NjhoLjU4N3oiIGZpbGw9IiNmZmYiLz48L3N2Zz4=)](https://thanks.dev/soywod)
+[![PayPal](https://img.shields.io/badge/-PayPal-0079c1?logo=PayPal&logoColor=ffffff)](https://www.paypal.com/paypalme/soywod)

--- a/README-PT.md
+++ b/README-PT.md
@@ -1,0 +1,429 @@
+<div align="center">
+  <img src="./logo.svg" alt="Logo" width="128" height="128" />
+  <h1>📫 Himalaya</h1>
+  <p>CLI para gerenciar e-mails</p>
+  <p>
+    <a href="https://github.com/pimalaya/himalaya/releases/latest"><img alt="Release" src="https://img.shields.io/github/v/release/pimalaya/himalaya?color=success"/></a>
+    <a href="https://repology.org/project/himalaya/versions"><img alt="Repology" src="https://img.shields.io/repology/repositories/himalaya?color=success"></a>
+    <a href="https://matrix.to/#/#pimalaya:matrix.org"><img alt="Matrix" src="https://img.shields.io/badge/chat-%23pimalaya-blue?style=flat&logo=matrix&logoColor=white"/></a>
+    <a href="https://fosstodon.org/@pimalaya"><img alt="Mastodon" src="https://img.shields.io/badge/news-%40pimalaya-blue?style=flat&logo=mastodon&logoColor=white"/></a>
+  </p>
+  <p>
+    <strong>Idiomas / Languages:</strong>
+    <a href="README.md">English</a> ·
+    <a href="README-ZH.md">中文</a> ·
+    <a href="README-ES.md">Español</a> ·
+    <a href="README-FR.md">Français</a> ·
+    <a href="README-PT.md">Português</a> ·
+    <a href="README-RU.md">Русский</a> ·
+    <a href="README-DE.md">Deutsch</a>
+  </p>
+</div>
+
+```
+himalaya envelopes list --account posteo -m Archives.FOSS --page 2
+```
+
+![screenshot](./screenshot.jpeg)
+
+> [!IMPORTANT]
+> Este README documenta o Himalaya v2, que **ainda não foi lançado**. Se você estiver usando a v1 (`himalaya v1.2.0` ou anterior), consulte o [README da v1.2.0](https://github.com/pimalaya/himalaya/blob/v1.2.0/README.md). O guia [MIGRATION.md](./MIGRATION.md) orienta usuários da v1 pelas mudanças incompatíveis.
+
+## Índice
+
+- [Recursos](#recursos)
+- [Instalação](#instalação)
+  - [Binário pré-compilado](#binário-pré-compilado)
+  - [Cargo](#cargo)
+  - [Arch Linux](#arch-linux)
+  - [Homebrew](#homebrew)
+  - [Scoop](#scoop)
+  - [Fedora Linux/CentOS/RHEL](#fedora-linuxcentosrhel)
+  - [Nix](#nix)
+  - [Código-fonte](#código-fonte)
+- [Configuração](#configuração)
+- [Uso](#uso)
+  - [API compartilhada](#api-compartilhada)
+  - [APIs específicas por protocolo](#apis-específicas-por-protocolo)
+  - [Composição de mensagens](#composição-de-mensagens)
+  - [Leitura de mensagens](#leitura-de-mensagens)
+  - [Reutilização de sessões](#reutilização-de-sessões)
+- [Interfaces](#interfaces)
+- [FAQ](#faq)
+- [Redes sociais](#redes-sociais)
+- [Patrocínio](#patrocínio)
+
+## Recursos
+
+- **API compartilhada** que mapeia `mailboxes`, `envelopes`, `flags`, `messages` e `attachments` para o backend ativo
+- **APIs específicas por protocolo** expondo a superfície completa de cada backend (`himalaya imap/smtp/maildir/jmap…`)
+- Suporte a **IMAP** <sup>[rfc9051](https://www.iana.org/go/rfc9051)</sup> (requer o recurso `imap`)
+- Suporte a **JMAP** <sup>[rfc8620](https://www.iana.org/go/rfc8620), [rfc8621](https://www.iana.org/go/rfc8621)</sup> (requer o recurso `jmap`)
+- Suporte a **Maildir** (requer o recurso `maildir`)
+- Backend **SMTP** <sup>[rfc5321](https://www.iana.org/go/rfc5321)</sup> (requer o recurso `smtp`)
+- Suporte a **TLS**:
+  - [native-tls](https://crates.io/crates/native-tls) (requer o recurso `native-tls`)
+  - [rustls](https://crates.io/crates/rustls):
+    - Provedor criptográfico AWS-LC (requer o recurso `rustls-aws`)
+    - Provedor criptográfico Ring (requer o recurso `rustls-ring`)
+- Suporte a **SASL**: anonymous, login, plain, oauthbearer, xoauth2, scram-sha-256
+- Assistente de **descoberta de provedores** baseado em [io-discovery](https://github.com/pimalaya/io-discovery): Thunderbird Autoconfiguration, PACC e consultas SRV RFC 6186
+- Configuração **TOML** com suporte a múltiplas contas
+- Saída **JSON** via `--json`
+
+*O Himalaya CLI é escrito em [Rust](https://www.rust-lang.org/) e depende de [cargo features](https://doc.rust-lang.org/cargo/reference/features.html) para habilitar ou desabilitar funcionalidades. Os recursos padrão podem ser encontrados na seção `features` do [`Cargo.toml`](./Cargo.toml#L18) ou em [docs.rs](https://docs.rs/crate/himalaya/latest/features).*
+
+## Instalação
+
+### Binário pré-compilado
+
+O Himalaya CLI pode ser instalado com o instalador `install.sh`:
+
+*Como root:*
+
+```
+curl -sSL https://raw.githubusercontent.com/pimalaya/himalaya/master/install.sh | sudo sh
+```
+
+*Como usuário comum:*
+
+```
+curl -sSL https://raw.githubusercontent.com/pimalaya/himalaya/master/install.sh | PREFIX=~/.local sh
+```
+
+Esses comandos instalam o binário mais recente da seção [releases](https://github.com/pimalaya/himalaya/releases) do GitHub.
+
+Se você quiser uma versão mais atual do que a última release, consulte o workflow [releases](https://github.com/pimalaya/himalaya/actions/workflows/releases.yml) do GitHub e procure a seção *Artifacts*. Você encontrará um binário pré-compilado compatível com o seu SO. Esses binários são compilados a partir do branch `master`.
+
+*Esses binários são compilados com os cargo features padrão. Se precisar de mais recursos, use outro método de instalação.*
+
+### Cargo
+
+O Himalaya CLI pode ser instalado com [cargo](https://doc.rust-lang.org/cargo/):
+
+```
+cargo install himalaya --locked
+```
+
+Somente com suporte a IMAP:
+
+```
+cargo install himalaya --locked --no-default-features --features imap
+```
+
+Você também pode usar o repositório git para uma versão mais atual (porém menos estável):
+
+```
+cargo install --locked --git https://github.com/pimalaya/himalaya.git
+```
+
+### Arch Linux
+
+O Himalaya CLI pode ser instalado no [Arch Linux](https://archlinux.org/) pelo repositório community:
+
+```
+pacman -S himalaya
+```
+
+ou pelo [repositório de usuários](https://aur.archlinux.org/):
+
+```
+git clone https://aur.archlinux.org/himalaya-git.git
+cd himalaya-git
+makepkg -isc
+```
+
+Se você usa [yay](https://github.com/Jguer/yay), é ainda mais simples:
+
+```
+yay -S himalaya-git
+```
+
+### Homebrew
+
+O Himalaya CLI pode ser instalado com [Homebrew](https://brew.sh/):
+
+```
+brew install himalaya
+```
+
+Nota: cargo features não são compatíveis com o brew. Se precisar de um conjunto diferente de recursos, use outro método de instalação.
+
+### Scoop
+
+O Himalaya CLI pode ser instalado com [Scoop](https://scoop.sh/):
+
+```
+scoop install himalaya
+```
+
+### Fedora Linux/CentOS/RHEL
+
+O Himalaya CLI pode ser instalado no [Fedora Linux](https://fedoraproject.org/)/CentOS/RHEL pelo repositório [COPR](https://copr.fedorainfracloud.org/coprs/atim/himalaya/):
+
+```
+dnf copr enable atim/himalaya
+dnf install himalaya
+```
+
+### Nix
+
+O Himalaya CLI pode ser instalado com [Nix](https://serokell.io/blog/what-is-nix):
+
+```
+nix-env -i himalaya
+```
+
+Você também pode usar o repositório git para uma versão mais atual (porém menos estável):
+
+```
+nix-env -if https://github.com/pimalaya/himalaya/archive/master.tar.gz
+```
+
+*Ou, a partir do checkout da árvore de código-fonte:*
+
+```
+nix-env -if .
+```
+
+Se você tiver o recurso [Flakes](https://nixos.wiki/wiki/Flakes) habilitado:
+
+```
+nix profile install github:pimalaya/himalaya
+```
+
+*Ou, a partir do checkout da árvore de código-fonte:*
+
+```
+nix profile install
+```
+
+*Você também pode executar o Himalaya diretamente sem instalá-lo:*
+
+```
+nix run github:pimalaya/himalaya
+```
+
+### Código-fonte
+
+```
+git clone https://github.com/pimalaya/himalaya
+cd himalaya
+nix develop --command cargo build --release
+```
+
+*Os binários ficam disponíveis na pasta `target/release`.*
+
+## Configuração
+
+Basta executar `himalaya`. Quando nenhum arquivo de configuração é encontrado, o assistente solicita um nome de conta e endereço de e-mail, executa a [descoberta de provedores](https://github.com/pimalaya/io-discovery) (PACC → Thunderbird Autoconfiguration → RFC 6186 SRV), preenche os prompts IMAP/SMTP (ou JMAP) com os valores descobertos e grava o resultado em disco.
+
+As contas podem ser (re)configuradas depois com `himalaya account configure <name>`. Nesse modo, o assistente pula a descoberta: reutiliza os valores existentes como padrões dos prompts.
+
+Você também pode escrever a configuração manualmente:
+
+- Copie o [./config.sample.toml](./config.sample.toml) documentado
+- Cole em um dos seguintes locais:
+  - `$XDG_CONFIG_HOME/himalaya/config.toml`
+  - `$HOME/.config/himalaya/config.toml`
+  - `$HOME/.himalayarc`
+- Comente ou descomente as opções desejadas
+
+…ou passe `-c <PATH>` / defina `HIMALAYA_CONFIG=<PATH>`. Vários caminhos podem ser passados de uma vez, separados por `:`; o primeiro é a base e os demais são mesclados profundamente por cima.
+
+## Uso
+
+### API compartilhada
+
+Comandos independentes de backend operam no primeiro backend configurado da conta, ou no selecionado com `-b/--backend`:
+
+```
+himalaya mailboxes list
+himalaya envelopes list -m INBOX --page 2
+himalaya envelopes search from alice and after 2026-01-01 order by date desc
+himalaya flags add -m INBOX --flag seen 1:3,5
+himalaya messages copy --from INBOX --to Archives 42
+himalaya attachments download -m INBOX 42
+```
+
+Quando o alias `inbox` está configurado em `[mailbox.alias]`, `-m/--mailbox` torna-se opcional: os comandos compartilhados recorrem a esse id. Com `[mailbox.alias] inbox = "INBOX"`, as chamadas acima se reduzem a `envelopes list --page 2`, `flags add --flag seen 1:3,5`, etc.
+
+`envelopes list` é paginação simples, ordenada por data decrescente. Para filtrar ou ordenar, use `envelopes search` com uma consulta final cobrindo condições `date`, `after`, `from`, `to`, `subject`, `body`, `flag` (combinadas com `and`, `or`, `not`, agrupadas com parênteses) e uma cadeia de ordenação `order by date|from|to|subject [asc|desc]`. Cláusulas de data visam o cabeçalho `Date:` (data de envio) em todos os backends.
+
+A superfície compartilhada é um subconjunto estrito do menor denominador comum entre IMAP, JMAP e Maildir. Operações que não generalizam (papéis de mailbox, flags de atributo, consultas específicas de JMAP…) ficam nos subcomandos específicos por protocolo.
+
+### APIs específicas por protocolo
+
+Cada backend expõe sua API nativa completa em seu próprio subgrupo:
+
+```
+himalaya imap mailboxes select INBOX
+himalaya imap mailboxes status INBOX
+himalaya imap mailboxes subscribe INBOX
+
+himalaya jmap mailboxes query --role drafts
+himalaya jmap identity get
+himalaya jmap vacation get
+
+himalaya maildir create Archives
+himalaya maildir messages save -m ~/Mail/example/Archives < message.eml
+
+himalaya smtp messages send < message.eml
+```
+
+A flag `-b/--backend` é consumida apenas pelos comandos compartilhados; subcomandos de protocolo sempre usam seu próprio backend.
+
+### Composição de mensagens
+
+Os comandos integrados `messages compose` / `reply` / `forward` cobrem casos simples via flags da CLI:
+
+```
+himalaya messages compose --from me@example.org --to you@example.org \
+    --subject "Hello" --body "Hi!" --send
+```
+
+Para composição mais rica (MIME multipart, diretivas MML, assinatura/criptografia, fluxos de trabalho com editor…), configure um compositor definido pelo usuário em `[message.composer.*]` e invoque-o com as variantes `-with`. Por exemplo, com [`mml`](https://github.com/pimalaya/mml):
+
+```toml
+[message.composer.mml]
+command = "mml compose"
+default = true
+```
+
+```
+himalaya messages compose-with
+himalaya messages reply-with -m INBOX 42 --send
+himalaya messages forward-with -m INBOX 42 --send
+himalaya messages mailto 'mailto:bob@example.org?subject=Hi&body=Hello'
+```
+
+`messages mailto <URI>` analisa uma URI RFC 6068 `mailto:` (lista de destinatários no caminho, parâmetros de consulta `to` / `cc` / `bcc` / `subject` / `body`), constrói um esqueleto RFC 5322 de rascunho com esses cabeçalhos pré-preenchidos e o envia via stdin para o compositor nomeado (ou padrão) para edição. A saída do compositor é encaminhada por `--save` / `--send` como nas outras variantes `-with`. Útil como manipulador de `mailto:` no desktop.
+
+### Leitura de mensagens
+
+O comando integrado `messages read` renderiza uma mensagem com o formatador padrão do himalaya. Para renderização personalizada, declare um leitor em `[message.reader.*]` e chame `read-with`:
+
+```toml
+[message.reader.mml]
+command = "mml read"
+default = true
+```
+
+```
+himalaya messages read-with -m INBOX 42
+```
+
+### Reutilização de sessões
+
+Cada invocação abre uma sessão TCP+TLS+SASL nova por padrão. Para amortizar o handshake em muitos comandos, combine o himalaya com [`sirup`](https://github.com/pimalaya/sirup): `sirup` expõe uma sessão IMAP/SMTP pré-autenticada por um socket Unix, e o himalaya pode apontar seu `imap.server` / `smtp.server` para esse socket.
+
+## Interfaces
+
+Essas interfaces são construídas sobre o Himalaya CLI para melhorar a experiência do usuário:
+
+- [pimalaya/himalaya-tui](https://github.com/pimalaya/himalaya-tui): TUI oficial (em desenvolvimento ativo)
+- [pimalaya/himalaya-vim](https://github.com/pimalaya/himalaya-vim): plugin Vim
+- [dantecatalfamo/himalaya-emacs](https://github.com/dantecatalfamo/himalaya-emacs): plugin Emacs
+- [jns/himalaya](https://www.raycast.com/jns/himalaya): extensão Raycast
+- [openclaw/openclaw](https://github.com/openclaw/openclaw/blob/main/skills/himalaya/SKILL.md): SKILL OpenClaw
+- [parisni/dfzf](https://github.com/parisni/dfzf): integração dfzf
+
+## FAQ
+
+<details>
+  <summary>Qual a diferença em relação ao aerc, mutt ou alpine?</summary>
+
+  Aerc, mutt e alpine podem ser categorizados como Interfaces de Usuário de Terminal (TUI). Quando o programa é executado, seu terminal fica bloqueado em um loop de eventos e você interage com seus e-mails usando atalhos de teclado.
+
+  O Himalaya é uma Interface de Linha de Comando (CLI). Não há loop de eventos: você interage com seus e-mails usando comandos de shell, de forma stateless.
+
+  Uma TUI dedicada ([himalaya-tui](https://github.com/pimalaya/himalaya-tui)) está em desenvolvimento ativo sobre as mesmas bibliotecas Pimalaya.
+</details>
+
+<details>
+  <summary>Como os segredos são resolvidos?</summary>
+
+  Todo campo `*.passwd` / `*.password` / `*.token` aceita um literal bruto ou um comando shell que imprime o segredo em stdout. A forma bruta é conveniente para testes, mas não deve ser usada em produção:
+
+  ```toml
+  imap.sasl.plain.passwd.raw = "***"
+  imap.sasl.plain.passwd.command = "pass show example"
+  imap.sasl.plain.passwd.command = ["pass", "show", "example"]
+  ```
+
+  O suporte nativo a keyring foi removido na v2. Use [pimalaya/mimosa](https://github.com/pimalaya/mimosa) (ou `pass`, `secret-tool`, `gopass`…) como `command`.
+</details>
+
+<details>
+  <summary>Como o OAuth 2.0 é tratado?</summary>
+
+  A v2 não inclui fluxos OAuth. Use [pimalaya/ortie](https://github.com/pimalaya/ortie) (ou qualquer outro broker de tokens) para obter um access token e conecte-o como um `command` que retorna o token em stdout. Para JMAP, aponte `jmap.auth.bearer.token.command` para o broker; para IMAP/SMTP, encaminhe o bearer por um mecanismo SASL que consome uma senha obtida via command.
+</details>
+
+<details>
+  <summary>Como o assistente descobre configurações IMAP/SMTP/JMAP?</summary>
+
+  O assistente executa três mecanismos de descoberta em série no domínio do endereço de e-mail; o primeiro resultado não vazio prevalece:
+
+  1. **PACC** <sup>[draft-ietf-mailmaint-pacc-02](https://datatracker.ietf.org/doc/html/draft-ietf-mailmaint-pacc-02)</sup>: JSON well-known, verificado por digest contra o registro TXT `_ua-auto-config`.
+  2. **Thunderbird Autoconfiguration**: consultas ISP main / well-known / ISPDB, depois nova tentativa baseada em MX, depois o redirecionamento TXT `mailconf=<URL>`.
+  3. **RFC 6186 SRV**: consultas `_imap._tcp`, `_imaps._tcp`, `_submission._tcp` reunidas em um único relatório.
+
+  Consulte [io-discovery](https://github.com/pimalaya/io-discovery) para a cadeia completa.
+</details>
+
+<details>
+  <summary>Como depurar o Himalaya CLI?</summary>
+
+  Use `--log-level <level>` (alias `--log`) onde `<level>` é um de `off`, `error`, `warn`, `info`, `debug`, `trace`:
+
+  ```
+  himalaya --log trace mailboxes list
+  ```
+
+  A variável de ambiente `RUST_LOG` é consultada quando `--log` não é passado e suporta filtros por alvo (consulte a [documentação do `env_logger`](https://docs.rs/env_logger/latest/env_logger/#enabling-logging)). `RUST_BACKTRACE=1` habilita backtraces completos de erro.
+
+  Os logs são escritos em `stderr`, então podem ser redirecionados facilmente para um arquivo:
+
+  ```
+  himalaya --log trace mailboxes list 2>/tmp/himalaya.log
+  ```
+
+  Você também pode enviar logs diretamente para um arquivo via `--log-file <path>`:
+
+  ```
+  himalaya --log trace --log-file /tmp/himalaya.log mailboxes list
+  ```
+</details>
+
+<details>
+  <summary>Como desabilitar a saída colorida?</summary>
+
+  Defina `NO_COLOR=1` no seu ambiente.
+</details>
+
+## Redes sociais
+
+- Chat no [Matrix](https://matrix.to/#/#pimalaya:matrix.org)
+- Notícias no [Mastodon](https://fosstodon.org/@pimalaya) ou [RSS](https://fosstodon.org/@pimalaya.rss)
+- E-mail em [pimalaya.org@posteo.net](mailto:pimalaya.org@posteo.net)
+
+## Patrocínio
+
+[![nlnet](https://nlnet.nl/logo/banner-160x60.png)](https://nlnet.nl/)
+
+Agradecimentos especiais à [fundação NLnet](https://nlnet.nl/) e à [Comissão Europeia](https://www.ngi.eu/) que vêm apoiando financeiramente o projeto há anos:
+
+- 2022 → 2023: [NGI Assure](https://nlnet.nl/project/Himalaya/)
+- 2023 → 2024: [NGI Zero Entrust](https://nlnet.nl/project/Pimalaya/)
+- 2024 → 2026: [NGI Zero Core](https://nlnet.nl/project/Pimalaya-PIM/)
+- *2027 em preparação…*
+
+Se você aprecia o projeto, sinta-se à vontade para doar usando um dos seguintes provedores:
+
+[![GitHub](https://img.shields.io/badge/-GitHub%20Sponsors-fafbfc?logo=GitHub%20Sponsors)](https://github.com/sponsors/soywod)
+[![Ko-fi](https://img.shields.io/badge/-Ko--fi-ff5e5a?logo=Ko-fi&logoColor=ffffff)](https://ko-fi.com/soywod)
+[![Buy Me a Coffee](https://img.shields.io/badge/-Buy%20Me%20a%20Coffee-ffdd00?logo=Buy%20Me%20A%20Coffee&logoColor=000000)](https://www.buymeacoffee.com/soywod)
+[![Liberapay](https://img.shields.io/badge/-Liberapay-f6c915?logo=Liberapay&logoColor=222222)](https://liberapay.com/soywod)
+[![thanks.dev](https://img.shields.io/badge/-thanks.dev-000000?logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQuMDk3IiBoZWlnaHQ9IjE3LjU5NyIgY2xhc3M9InctMzYgbWwtMiBsZzpteC0wIHByaW50Om14LTAgcHJpbnQ6aW52ZXJ0IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxwYXRoIGQ9Ik05Ljc4MyAxNy41OTdINy4zOThjLTEuMTY4IDAtMi4wOTItLjI5Ny0yLjc3My0uODktLjY4LS41OTMtMS4wMi0xLjQ2Mi0xLjAyLTIuNjA2di0xLjM0NmMwLTEuMDE4LS4yMjctMS43NS0uNjc4LTIuMTk1LS40NTItLjQ0Ni0xLjIzMi0uNjY5LTIuMzQtLjY2OUgwVjcuNzA1aC41ODdjMS4xMDggMCAxLjg4OC0uMjIyIDIuMzQtLjY2OC40NTEtLjQ0Ni42NzctMS4xNzcuNjc3LTIuMTk1VjMuNDk2YzAtMS4xNDQuMzQtMi4wMTMgMS4wMjEtMi42MDZDNS4zMDUuMjk3IDYuMjMgMCA3LjM5OCAwaDIuMzg1djEuOTg3aC0uOTg1Yy0uMzYxIDAtLjY4OC4wMjctLjk4LjA4MmExLjcxOSAxLjcxOSAwIDAgMC0uNzM2LjMwN2MtLjIwNS4xNTYtLjM1OC4zODQtLjQ2LjY4Mi0uMTAzLjI5OC0uMTU0LjY4Mi0uMTU0IDEuMTUxVjUuMjNjMCAuODY3LS4yNDkgMS41ODYtLjc0NSAyLjE1NS0uNDk3LjU2OS0xLjE1OCAxLjAwNC0xLjk4MyAxLjMwNXYuMjE3Yy44MjUuMyAxLjQ4Ni43MzYgMS45ODMgMS4zMDUuNDk2LjU3Ljc0NSAxLjI4Ny43NDUgMi4xNTR2MS4wMjFjMCAuNDcuMDUxLjg1NC4xNTMgMS4xNTIuMTAzLjI5OC4yNTYuNTI1LjQ2MS42ODIuMTkzLjE1Ny40MzcuMjYuNzMyLjMxMi4yOTUuMDUuNjIzLjA3Ni45ODQuMDc2aC45ODVabTE0LjMxNC03LjcwNmgtLjU4OGMtMS4xMDggMC0xLjg4OC4yMjMtMi4zNC42NjktLjQ1LjQ0NS0uNjc3IDEuMTc3LS42NzcgMi4xOTVWMTQuMWMwIDEuMTQ0LS4zNCAyLjAxMy0xLjAyIDIuNjA2LS42OC41OTMtMS42MDUuODktMi43NzQuODloLTIuMzg0di0xLjk4OGguOTg0Yy4zNjIgMCAuNjg4LS4wMjcuOTgtLjA4LjI5Mi0uMDU1LjUzOC0uMTU3LjczNy0uMzA4LjIwNC0uMTU3LjM1OC0uMzg0LjQ2LS42ODIuMTAzLS4yOTguMTU0LS42ODIuMTU0LTEuMTUydi0xLjAyYzAtLjg2OC4yNDgtMS41ODYuNzQ1LTIuMTU1LjQ5Ny0uNTcgMS4xNTgtMS4wMDQgMS45ODMtMS4zMDV2LS4yMTdjLS44MjUtLjMwMS0xLjQ4Ni0uNzM2LTEuOTgzLTEuMzA1LS40OTctLjU3LS43NDUtMS4yODgtLjc0NS0yLjE1NXYtMS4wMmMwLS40Ny0uMDUxLS44NTQtLjE1NC0xLjE1Mi0uMTAyLS4yOTgtLjI1Ni0uNTI2LS40Ni0uNjgyYTEuNzE5IDEuNzE5IDAgMCAwLS43MzctLjMwNyA1LjM5NSA1LjM5NSAwIDAgMC0uOTgtLjA4MmgtLjk4NFYwaDIuMzg0YzEuMTY5IDAgMi4wOTMuMjk3IDIuNzc0Ljg5LjY4LjU5MyAxLjAyIDEuNDYyIDEuMDIgMi42MDZ2MS4zNDZjMCAxLjAxOC4yMjYgMS43NS42NzggMi4xOTUuNDUxLjQ0NiAxLjIzMS42NjggMi4zNC42NjhoLjU4N3oiIGZpbGw9IiNmZmYiLz48L3N2Zz4=)](https://thanks.dev/soywod)
+[![PayPal](https://img.shields.io/badge/-PayPal-0079c1?logo=PayPal&logoColor=ffffff)](https://www.paypal.com/paypalme/soywod)

--- a/README-RU.md
+++ b/README-RU.md
@@ -1,0 +1,429 @@
+<div align="center">
+  <img src="./logo.svg" alt="Logo" width="128" height="128" />
+  <h1>📫 Himalaya</h1>
+  <p>CLI для управления почтой</p>
+  <p>
+    <a href="https://github.com/pimalaya/himalaya/releases/latest"><img alt="Release" src="https://img.shields.io/github/v/release/pimalaya/himalaya?color=success"/></a>
+    <a href="https://repology.org/project/himalaya/versions"><img alt="Repology" src="https://img.shields.io/repology/repositories/himalaya?color=success"></a>
+    <a href="https://matrix.to/#/#pimalaya:matrix.org"><img alt="Matrix" src="https://img.shields.io/badge/chat-%23pimalaya-blue?style=flat&logo=matrix&logoColor=white"/></a>
+    <a href="https://fosstodon.org/@pimalaya"><img alt="Mastodon" src="https://img.shields.io/badge/news-%40pimalaya-blue?style=flat&logo=mastodon&logoColor=white"/></a>
+  </p>
+  <p>
+    <strong>Языки / Languages:</strong>
+    <a href="README.md">English</a> ·
+    <a href="README-ZH.md">中文</a> ·
+    <a href="README-ES.md">Español</a> ·
+    <a href="README-FR.md">Français</a> ·
+    <a href="README-PT.md">Português</a> ·
+    <a href="README-RU.md">Русский</a> ·
+    <a href="README-DE.md">Deutsch</a>
+  </p>
+</div>
+
+```
+himalaya envelopes list --account posteo -m Archives.FOSS --page 2
+```
+
+![screenshot](./screenshot.jpeg)
+
+> [!IMPORTANT]
+> Этот README описывает Himalaya v2, который **ещё не выпущен**. Если вы используете v1 (`himalaya v1.2.0` или ранее), обратитесь к [README v1.2.0](https://github.com/pimalaya/himalaya/blob/v1.2.0/README.md). Руководство [MIGRATION.md](./MIGRATION.md) поможет пользователям v1 разобраться с несовместимыми изменениями.
+
+## Содержание
+
+- [Возможности](#возможности)
+- [Установка](#установка)
+  - [Готовый бинарник](#готовый-бинарник)
+  - [Cargo](#cargo)
+  - [Arch Linux](#arch-linux)
+  - [Homebrew](#homebrew)
+  - [Scoop](#scoop)
+  - [Fedora Linux/CentOS/RHEL](#fedora-linuxcentosrhel)
+  - [Nix](#nix)
+  - [Исходники](#исходники)
+- [Настройка](#настройка)
+- [Использование](#использование)
+  - [Общий API](#общий-api)
+  - [API для конкретных протоколов](#api-для-конкретных-протоколов)
+  - [Составление сообщений](#составление-сообщений)
+  - [Чтение сообщений](#чтение-сообщений)
+  - [Повторное использование сессий](#повторное-использование-сессий)
+- [Интерфейсы](#интерфейсы)
+- [FAQ](#faq)
+- [Соцсети](#соцсети)
+- [Спонсорство](#спонсорство)
+
+## Возможности
+
+- **Общий API**, сопоставляющий `mailboxes`, `envelopes`, `flags`, `messages` и `attachments` с активным бэкендом
+- **API для конкретных протоколов**, раскрывающие полный набор возможностей каждого бэкенда (`himalaya imap/smtp/maildir/jmap…`)
+- Поддержка **IMAP** <sup>[rfc9051](https://www.iana.org/go/rfc9051)</sup> (требуется feature `imap`)
+- Поддержка **JMAP** <sup>[rfc8620](https://www.iana.org/go/rfc8620), [rfc8621](https://www.iana.org/go/rfc8621)</sup> (требуется feature `jmap`)
+- Поддержка **Maildir** (требуется feature `maildir`)
+- Бэкенд **SMTP** <sup>[rfc5321](https://www.iana.org/go/rfc5321)</sup> (требуется feature `smtp`)
+- Поддержка **TLS**:
+  - [native-tls](https://crates.io/crates/native-tls) (требуется feature `native-tls`)
+  - [rustls](https://crates.io/crates/rustls):
+    - Криптопровайдер AWS-LC (требуется feature `rustls-aws`)
+    - Криптопровайдер Ring (требуется feature `rustls-ring`)
+- Поддержка **SASL**: anonymous, login, plain, oauthbearer, xoauth2, scram-sha-256
+- Мастер **обнаружения провайдера** на базе [io-discovery](https://github.com/pimalaya/io-discovery): Thunderbird Autoconfiguration, PACC и SRV-запросы RFC 6186
+- **TOML**-конфигурация с поддержкой нескольких аккаунтов
+- **JSON**-вывод через `--json`
+
+*Himalaya CLI написан на [Rust](https://www.rust-lang.org/) и использует [cargo features](https://doc.rust-lang.org/cargo/reference/features.html) для включения или отключения функций. Стандартные features можно найти в разделе `features` файла [`Cargo.toml`](./Cargo.toml#L18) или на [docs.rs](https://docs.rs/crate/himalaya/latest/features).*
+
+## Установка
+
+### Готовый бинарник
+
+Himalaya CLI можно установить с помощью установщика `install.sh`:
+
+*От root:*
+
+```
+curl -sSL https://raw.githubusercontent.com/pimalaya/himalaya/master/install.sh | sudo sh
+```
+
+*От обычного пользователя:*
+
+```
+curl -sSL https://raw.githubusercontent.com/pimalaya/himalaya/master/install.sh | PREFIX=~/.local sh
+```
+
+Эти команды устанавливают последний бинарник из раздела [releases](https://github.com/pimalaya/himalaya/releases) на GitHub.
+
+Если вам нужна более свежая версия, чем последний релиз, посмотрите workflow [releases](https://github.com/pimalaya/himalaya/actions/workflows/releases.yml) на GitHub и найдите раздел *Artifacts*. Там будет готовый бинарник для вашей ОС. Эти бинарники собираются из ветки `master`.
+
+*Такие бинарники собираются со стандартными cargo features. Если нужны дополнительные features, используйте другой способ установки.*
+
+### Cargo
+
+Himalaya CLI можно установить через [cargo](https://doc.rust-lang.org/cargo/):
+
+```
+cargo install himalaya --locked
+```
+
+Только с поддержкой IMAP:
+
+```
+cargo install himalaya --locked --no-default-features --features imap
+```
+
+Также можно использовать git-репозиторий для более свежей (но менее стабильной) версии:
+
+```
+cargo install --locked --git https://github.com/pimalaya/himalaya.git
+```
+
+### Arch Linux
+
+Himalaya CLI можно установить на [Arch Linux](https://archlinux.org/) из community-репозитория:
+
+```
+pacman -S himalaya
+```
+
+или из [AUR](https://aur.archlinux.org/):
+
+```
+git clone https://aur.archlinux.org/himalaya-git.git
+cd himalaya-git
+makepkg -isc
+```
+
+Если вы используете [yay](https://github.com/Jguer/yay), это ещё проще:
+
+```
+yay -S himalaya-git
+```
+
+### Homebrew
+
+Himalaya CLI можно установить через [Homebrew](https://brew.sh/):
+
+```
+brew install himalaya
+```
+
+Примечание: cargo features несовместимы с brew. Если нужен другой набор features, используйте другой способ установки.
+
+### Scoop
+
+Himalaya CLI можно установить через [Scoop](https://scoop.sh/):
+
+```
+scoop install himalaya
+```
+
+### Fedora Linux/CentOS/RHEL
+
+Himalaya CLI можно установить на [Fedora Linux](https://fedoraproject.org/)/CentOS/RHEL через репозиторий [COPR](https://copr.fedorainfracloud.org/coprs/atim/himalaya/):
+
+```
+dnf copr enable atim/himalaya
+dnf install himalaya
+```
+
+### Nix
+
+Himalaya CLI можно установить через [Nix](https://serokell.io/blog/what-is-nix):
+
+```
+nix-env -i himalaya
+```
+
+Также можно использовать git-репозиторий для более свежей (но менее стабильной) версии:
+
+```
+nix-env -if https://github.com/pimalaya/himalaya/archive/master.tar.gz
+```
+
+*Или из checkout исходного дерева:*
+
+```
+nix-env -if .
+```
+
+Если у вас включена функция [Flakes](https://nixos.wiki/wiki/Flakes):
+
+```
+nix profile install github:pimalaya/himalaya
+```
+
+*Или из checkout исходного дерева:*
+
+```
+nix profile install
+```
+
+*Также можно запускать Himalaya напрямую без установки:*
+
+```
+nix run github:pimalaya/himalaya
+```
+
+### Исходники
+
+```
+git clone https://github.com/pimalaya/himalaya
+cd himalaya
+nix develop --command cargo build --release
+```
+
+*Бинарники доступны в папке `target/release`.*
+
+## Настройка
+
+Просто запустите `himalaya`. Если конфигурационный файл не найден, мастер запросит имя аккаунта и адрес электронной почты, выполнит [обнаружение провайдера](https://github.com/pimalaya/io-discovery) (PACC → Thunderbird Autoconfiguration → RFC 6186 SRV), заполнит запросы IMAP/SMTP (или JMAP) обнаруженными значениями по умолчанию и запишет результат на диск.
+
+Аккаунты можно (пере)настроить позже командой `himalaya account configure <name>`. В этом режиме мастер пропускает обнаружение: он повторно использует существующие значения как значения по умолчанию для запросов.
+
+Конфигурацию также можно написать вручную:
+
+- Скопируйте документированный [./config.sample.toml](./config.sample.toml)
+- Вставьте в один из путей:
+  - `$XDG_CONFIG_HOME/himalaya/config.toml`
+  - `$HOME/.config/himalaya/config.toml`
+  - `$HOME/.himalayarc`
+- Закомментируйте или раскомментируйте нужные опции
+
+…или передайте `-c <PATH>` / установите `HIMALAYA_CONFIG=<PATH>`. Можно передать несколько путей сразу, разделённых `:`; первый — базовый, остальные глубоко объединяются поверх.
+
+## Использование
+
+### Общий API
+
+Команды, не зависящие от бэкенда, работают с первым настроенным бэкендом аккаунта или с выбранным через `-b/--backend`:
+
+```
+himalaya mailboxes list
+himalaya envelopes list -m INBOX --page 2
+himalaya envelopes search from alice and after 2026-01-01 order by date desc
+himalaya flags add -m INBOX --flag seen 1:3,5
+himalaya messages copy --from INBOX --to Archives 42
+himalaya attachments download -m INBOX 42
+```
+
+Когда alias `inbox` настроен в `[mailbox.alias]`, `-m/--mailbox` становится необязательным: общие команды используют этот id по умолчанию. При `[mailbox.alias] inbox = "INBOX"` вызовы выше сокращаются до `envelopes list --page 2`, `flags add --flag seen 1:3,5` и т.д.
+
+`envelopes list` — простая пагинация, отсортированная по дате по убыванию. Для фильтрации или сортировки используйте `envelopes search` с завершающим запросом, охватывающим условия `date`, `after`, `from`, `to`, `subject`, `body`, `flag` (объединённые через `and`, `or`, `not`, с группировкой в скобках) и цепочку сортировки `order by date|from|to|subject [asc|desc]`. Условия по дате относятся к заголовку `Date:` (время отправки) на всех бэкендах.
+
+Общая поверхность — строгое подмножество наименьшего общего знаменателя для IMAP, JMAP и Maildir. Операции, которые не обобщаются (роли почтовых ящиков, атрибутные флаги, JMAP-специфичные запросы…), находятся в подкомандах для конкретных протоколов.
+
+### API для конкретных протоколов
+
+Каждый бэкенд раскрывает свой полный нативный API в собственной подгруппе:
+
+```
+himalaya imap mailboxes select INBOX
+himalaya imap mailboxes status INBOX
+himalaya imap mailboxes subscribe INBOX
+
+himalaya jmap mailboxes query --role drafts
+himalaya jmap identity get
+himalaya jmap vacation get
+
+himalaya maildir create Archives
+himalaya maildir messages save -m ~/Mail/example/Archives < message.eml
+
+himalaya smtp messages send < message.eml
+```
+
+Флаг `-b/--backend` используется только общими командами; подкоманды протоколов всегда используют свой собственный бэкенд.
+
+### Составление сообщений
+
+Встроенные команды `messages compose` / `reply` / `forward` покрывают простые случаи через флаги CLI:
+
+```
+himalaya messages compose --from me@example.org --to you@example.org \
+    --subject "Hello" --body "Hi!" --send
+```
+
+Для более богатого составления (multipart MIME, директивы MML, подпись/шифрование, рабочие процессы через редактор…) настройте пользовательский композер в `[message.composer.*]` и вызывайте его через варианты `-with`. Например, с [`mml`](https://github.com/pimalaya/mml):
+
+```toml
+[message.composer.mml]
+command = "mml compose"
+default = true
+```
+
+```
+himalaya messages compose-with
+himalaya messages reply-with -m INBOX 42 --send
+himalaya messages forward-with -m INBOX 42 --send
+himalaya messages mailto 'mailto:bob@example.org?subject=Hi&body=Hello'
+```
+
+`messages mailto <URI>` разбирает URI RFC 6068 `mailto:` (список получателей в пути, query-параметры `to` / `cc` / `bcc` / `subject` / `body`), создаёт черновой каркас RFC 5322 с предзаполненными заголовками и передаёт его на stdin именованному (или стандартному) композеру для редактирования. Вывод композера направляется через `--save` / `--send`, как и у других вариантов `-with`. Полезно как обработчик `mailto:` на рабочем столе.
+
+### Чтение сообщений
+
+Встроенная команда `messages read` отображает сообщение с форматтером himalaya по умолчанию. Для пользовательского отображения объявите reader в `[message.reader.*]` и вызовите `read-with`:
+
+```toml
+[message.reader.mml]
+command = "mml read"
+default = true
+```
+
+```
+himalaya messages read-with -m INBOX 42
+```
+
+### Повторное использование сессий
+
+Каждый вызов по умолчанию открывает новую сессию TCP+TLS+SASL. Чтобы амортизировать рукопожатие на множестве команд, используйте himalaya вместе с [`sirup`](https://github.com/pimalaya/sirup): `sirup` предоставляет предварительно аутентифицированную сессию IMAP/SMTP через Unix-сокет, а himalaya может направить свой `imap.server` / `smtp.server` на этот сокет.
+
+## Интерфейсы
+
+Эти интерфейсы построены поверх Himalaya CLI для улучшения пользовательского опыта:
+
+- [pimalaya/himalaya-tui](https://github.com/pimalaya/himalaya-tui): официальный TUI (в активной разработке)
+- [pimalaya/himalaya-vim](https://github.com/pimalaya/himalaya-vim): плагин Vim
+- [dantecatalfamo/himalaya-emacs](https://github.com/dantecatalfamo/himalaya-emacs): плагин Emacs
+- [jns/himalaya](https://www.raycast.com/jns/himalaya): расширение Raycast
+- [openclaw/openclaw](https://github.com/openclaw/openclaw/blob/main/skills/himalaya/SKILL.md): SKILL OpenClaw
+- [parisni/dfzf](https://github.com/parisni/dfzf): интеграция dfzf
+
+## FAQ
+
+<details>
+  <summary>Чем он отличается от aerc, mutt или alpine?</summary>
+
+  Aerc, mutt и alpine можно отнести к терминальным пользовательским интерфейсам (TUI). При запуске программы терминал блокируется в цикле событий, и вы взаимодействуете с почтой с помощью горячих клавиш.
+
+  Himalaya — это интерфейс командной строки (CLI). Цикла событий нет: вы работаете с почтой через shell-команды, без сохранения состояния.
+
+  Специализированный TUI ([himalaya-tui](https://github.com/pimalaya/himalaya-tui)) активно разрабатывается на тех же библиотеках Pimalaya.
+</details>
+
+<details>
+  <summary>Как разрешаются секреты?</summary>
+
+  Каждое поле `*.passwd` / `*.password` / `*.token` принимает либо сырой литерал, либо shell-команду, выводящую секрет в stdout. Сырой вариант удобен для тестирования, но не должен использоваться в production:
+
+  ```toml
+  imap.sasl.plain.passwd.raw = "***"
+  imap.sasl.plain.passwd.command = "pass show example"
+  imap.sasl.plain.passwd.command = ["pass", "show", "example"]
+  ```
+
+  Нативная поддержка keyring была удалена в v2. Используйте [pimalaya/mimosa](https://github.com/pimalaya/mimosa) (или `pass`, `secret-tool`, `gopass`…) в качестве `command`.
+</details>
+
+<details>
+  <summary>Как обрабатывается OAuth 2.0?</summary>
+
+  v2 не включает OAuth-потоки. Используйте [pimalaya/ortie](https://github.com/pimalaya/ortie) (или любой другой брокер токенов), чтобы получить access token, и подключите его как `command`, возвращающий токен в stdout. Для JMAP укажите `jmap.auth.bearer.token.command` на брокер; для IMAP/SMTP направьте bearer через SASL-механизм, потребляющий пароль из command.
+</details>
+
+<details>
+  <summary>Как мастер обнаруживает конфигурации IMAP/SMTP/JMAP?</summary>
+
+  Мастер последовательно запускает три механизма обнаружения для домена адреса электронной почты; побеждает первый непустой результат:
+
+  1. **PACC** <sup>[draft-ietf-mailmaint-pacc-02](https://datatracker.ietf.org/doc/html/draft-ietf-mailmaint-pacc-02)</sup>: well-known JSON, проверенный digest против TXT-записи `_ua-auto-config`.
+  2. **Thunderbird Autoconfiguration**: запросы ISP main / well-known / ISPDB, затем повторная попытка по MX, затем TXT-перенаправление `mailconf=<URL>`.
+  3. **RFC 6186 SRV**: запросы `_imap._tcp`, `_imaps._tcp`, `_submission._tcp`, собранные в один отчёт.
+
+  Полную цепочку см. в [io-discovery](https://github.com/pimalaya/io-discovery).
+</details>
+
+<details>
+  <summary>Как отладить Himalaya CLI?</summary>
+
+  Используйте `--log-level <level>` (алиас `--log`), где `<level>` — одно из `off`, `error`, `warn`, `info`, `debug`, `trace`:
+
+  ```
+  himalaya --log trace mailboxes list
+  ```
+
+  Переменная окружения `RUST_LOG` учитывается, когда `--log` не передан, и поддерживает фильтры по целям (см. [документацию `env_logger`](https://docs.rs/env_logger/latest/env_logger/#enabling-logging)). `RUST_BACKTRACE=1` включает полные backtrace ошибок.
+
+  Логи пишутся в `stderr`, поэтому их легко перенаправить в файл:
+
+  ```
+  himalaya --log trace mailboxes list 2>/tmp/himalaya.log
+  ```
+
+  Также можно отправлять логи прямо в файл через `--log-file <path>`:
+
+  ```
+  himalaya --log trace --log-file /tmp/himalaya.log mailboxes list
+  ```
+</details>
+
+<details>
+  <summary>Как отключить цветной вывод?</summary>
+
+  Установите `NO_COLOR=1` в окружении.
+</details>
+
+## Соцсети
+
+- Чат в [Matrix](https://matrix.to/#/#pimalaya:matrix.org)
+- Новости в [Mastodon](https://fosstodon.org/@pimalaya) или [RSS](https://fosstodon.org/@pimalaya.rss)
+- Почта: [pimalaya.org@posteo.net](mailto:pimalaya.org@posteo.net)
+
+## Спонсорство
+
+[![nlnet](https://nlnet.nl/logo/banner-160x60.png)](https://nlnet.nl/)
+
+Особая благодарность [фонду NLnet](https://nlnet.nl/) и [Европейской комиссии](https://www.ngi.eu/), которые финансово поддерживают проект уже много лет:
+
+- 2022 → 2023: [NGI Assure](https://nlnet.nl/project/Himalaya/)
+- 2023 → 2024: [NGI Zero Entrust](https://nlnet.nl/project/Pimalaya/)
+- 2024 → 2026: [NGI Zero Core](https://nlnet.nl/project/Pimalaya-PIM/)
+- *2027 в подготовке…*
+
+Если вам нравится проект, вы можете поддержать его через одного из следующих провайдеров:
+
+[![GitHub](https://img.shields.io/badge/-GitHub%20Sponsors-fafbfc?logo=GitHub%20Sponsors)](https://github.com/sponsors/soywod)
+[![Ko-fi](https://img.shields.io/badge/-Ko--fi-ff5e5a?logo=Ko-fi&logoColor=ffffff)](https://ko-fi.com/soywod)
+[![Buy Me a Coffee](https://img.shields.io/badge/-Buy%20Me%20a%20Coffee-ffdd00?logo=Buy%20Me%20A%20Coffee&logoColor=000000)](https://www.buymeacoffee.com/soywod)
+[![Liberapay](https://img.shields.io/badge/-Liberapay-f6c915?logo=Liberapay&logoColor=222222)](https://liberapay.com/soywod)
+[![thanks.dev](https://img.shields.io/badge/-thanks.dev-000000?logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQuMDk3IiBoZWlnaHQ9IjE3LjU5NyIgY2xhc3M9InctMzYgbWwtMiBsZzpteC0wIHByaW50Om14LTAgcHJpbnQ6aW52ZXJ0IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxwYXRoIGQ9Ik05Ljc4MyAxNy41OTdINy4zOThjLTEuMTY4IDAtMi4wOTItLjI5Ny0yLjc3My0uODktLjY4LS41OTMtMS4wMi0xLjQ2Mi0xLjAyLTIuNjA2di0xLjM0NmMwLTEuMDE4LS4yMjctMS43NS0uNjc4LTIuMTk1LS40NTItLjQ0Ni0xLjIzMi0uNjY5LTIuMzQtLjY2OUgwVjcuNzA1aC41ODdjMS4xMDggMCAxLjg4OC0uMjIyIDIuMzQtLjY2OC40NTEtLjQ0Ni42NzctMS4xNzcuNjc3LTIuMTk1VjMuNDk2YzAtMS4xNDQuMzQtMi4wMTMgMS4wMjEtMi42MDZDNS4zMDUuMjk3IDYuMjMgMCA3LjM5OCAwaDIuMzg1djEuOTg3aC0uOTg1Yy0uMzYxIDAtLjY4OC4wMjctLjk4LjA4MmExLjcxOSAxLjcxOSAwIDAgMC0uNzM2LjMwN2MtLjIwNS4xNTYtLjM1OC4zODQtLjQ2LjY4Mi0uMTAzLjI5OC0uMTU0LjY4Mi0uMTU0IDEuMTUxVjUuMjNjMCAuODY3LS4yNDkgMS41ODYtLjc0NSAyLjE1NS0uNDk3LjU2OS0xLjE1OCAxLjAwNC0xLjk4MyAxLjMwNXYuMjE3Yy44MjUuMyAxLjQ4Ni43MzYgMS45ODMgMS4zMDUuNDk2LjU3Ljc0NSAxLjI4Ny43NDUgMi4xNTR2MS4wMjFjMCAuNDcuMDUxLjg1NC4xNTMgMS4xNTIuMTAzLjI5OC4yNTYuNTI1LjQ2MS42ODIuMTkzLjE1Ny40MzcuMjYuNzMyLjMxMi4yOTUuMDUuNjIzLjA3Ni45ODQuMDc2aC45ODVabTE0LjMxNC03LjcwNmgtLjU4OGMtMS4xMDggMC0xLjg4OC4yMjMtMi4zNC42NjktLjQ1LjQ0NS0uNjc3IDEuMTc3LS42NzcgMi4xOTVWMTQuMWMwIDEuMTQ0LS4zNCAyLjAxMy0xLjAyIDIuNjA2LS42OC41OTMtMS42MDUuODktMi43NzQuODloLTIuMzg0di0xLjk4OGguOTg0Yy4zNjIgMCAuNjg4LS4wMjcuOTgtLjA4LjI5Mi0uMDU1LjUzOC0uMTU3LjczNy0uMzA4LjIwNC0uMTU3LjM1OC0uMzg0LjQ2LS42ODIuMTAzLS4yOTguMTU0LS42ODIuMTU0LTEuMTUydi0xLjAyYzAtLjg2OC4yNDgtMS41ODYuNzQ1LTIuMTU1LjQ5Ny0uNTcgMS4xNTgtMS4wMDQgMS45ODMtMS4zMDV2LS4yMTdjLS44MjUtLjMwMS0xLjQ4Ni0uNzM2LTEuOTgzLTEuMzA1LS40OTctLjU3LS43NDUtMS4yODgtLjc0NS0yLjE1NXYtMS4wMmMwLS40Ny0uMDUxLS44NTQtLjE1NC0xLjE1Mi0uMTAyLS4yOTgtLjI1Ni0uNTI2LS40Ni0uNjgyYTEuNzE5IDEuNzE5IDAgMCAwLS43MzctLjMwNyA1LjM5NSA1LjM5NSAwIDAgMC0uOTgtLjA4MmgtLjk4NFYwaDIuMzg0YzEuMTY5IDAgMi4wOTMuMjk3IDIuNzc0Ljg5LjY4LjU5MyAxLjAyIDEuNDYyIDEuMDIgMi42MDZ2MS4zNDZjMCAxLjAxOC4yMjYgMS43NS42NzggMi4xOTUuNDUxLjQ0NiAxLjIzMS42NjggMi4zNC42NjhoLjU4N3oiIGZpbGw9IiNmZmYiLz48L3N2Zz4=)](https://thanks.dev/soywod)
+[![PayPal](https://img.shields.io/badge/-PayPal-0079c1?logo=PayPal&logoColor=ffffff)](https://www.paypal.com/paypalme/soywod)

--- a/README-ZH.md
+++ b/README-ZH.md
@@ -1,0 +1,429 @@
+<div align="center">
+  <img src="./logo.svg" alt="Logo" width="128" height="128" />
+  <h1>📫 Himalaya</h1>
+  <p>CLI 管理邮件</p>
+  <p>
+    <a href="https://github.com/pimalaya/himalaya/releases/latest"><img alt="Release" src="https://img.shields.io/github/v/release/pimalaya/himalaya?color=success"/></a>
+    <a href="https://repology.org/project/himalaya/versions"><img alt="Repology" src="https://img.shields.io/repology/repositories/himalaya?color=success"></a>
+    <a href="https://matrix.to/#/#pimalaya:matrix.org"><img alt="Matrix" src="https://img.shields.io/badge/chat-%23pimalaya-blue?style=flat&logo=matrix&logoColor=white"/></a>
+    <a href="https://fosstodon.org/@pimalaya"><img alt="Mastodon" src="https://img.shields.io/badge/news-%40pimalaya-blue?style=flat&logo=mastodon&logoColor=white"/></a>
+  </p>
+  <p>
+    <strong>语言 / Languages:</strong>
+    <a href="README.md">English</a> ·
+    <a href="README-ZH.md">中文</a> ·
+    <a href="README-ES.md">Español</a> ·
+    <a href="README-FR.md">Français</a> ·
+    <a href="README-PT.md">Português</a> ·
+    <a href="README-RU.md">Русский</a> ·
+    <a href="README-DE.md">Deutsch</a>
+  </p>
+</div>
+
+```
+himalaya envelopes list --account posteo -m Archives.FOSS --page 2
+```
+
+![screenshot](./screenshot.jpeg)
+
+> [!IMPORTANT]
+> 本 README 记录的是尚未发布的 Himalaya v2。若你正在使用 v1（`himalaya v1.2.0` 或更早版本），请参阅 [v1.2.0 README](https://github.com/pimalaya/himalaya/blob/v1.2.0/README.md)。[MIGRATION.md](./MIGRATION.md) 指南可帮助 v1 用户了解破坏性变更。
+
+## 目录
+
+- [功能](#features)
+- [安装](#installation)
+  - [预编译二进制](#pre-built-binary)
+  - [Cargo](#cargo)
+  - [Arch Linux](#arch-linux)
+  - [Homebrew](#homebrew)
+  - [Scoop](#scoop)
+  - [Fedora Linux/CentOS/RHEL](#fedora-linuxcentosrhel)
+  - [Nix](#nix)
+  - [源码](#sources)
+- [配置](#configuration)
+- [用法](#usage)
+  - [共享 API](#shared-api)
+  - [协议专用 API](#protocol-specific-apis)
+  - [撰写邮件](#composing-messages)
+  - [阅读邮件](#reading-messages)
+  - [复用会话](#re-using-sessions)
+- [界面](#interfaces)
+- [常见问题](#faq)
+- [社区](#social)
+- [赞助](#sponsoring)
+
+## 功能
+
+- **共享 API**，将 `mailboxes`、`envelopes`、`flags`、`messages` 和 `attachments` 映射到当前后端
+- **协议专用 API**，暴露各后端的完整能力（`himalaya imap/smtp/maildir/jmap…`）
+- **IMAP** 支持 <sup>[rfc9051](https://www.iana.org/go/rfc9051)</sup>（需要 `imap` feature）
+- **JMAP** 支持 <sup>[rfc8620](https://www.iana.org/go/rfc8620), [rfc8621](https://www.iana.org/go/rfc8621)</sup>（需要 `jmap` feature）
+- **Maildir** 支持（需要 `maildir` feature）
+- **SMTP** 后端 <sup>[rfc5321](https://www.iana.org/go/rfc5321)</sup>（需要 `smtp` feature）
+- **TLS** 支持：
+  - [native-tls](https://crates.io/crates/native-tls)（需要 `native-tls` feature）
+  - [rustls](https://crates.io/crates/rustls)：
+    - AWS-LC 加密提供方（需要 `rustls-aws` feature）
+    - Ring 加密提供方（需要 `rustls-ring` feature）
+- **SASL** 支持：anonymous、login、plain、oauthbearer、xoauth2、scram-sha-256
+- 由 [io-discovery](https://github.com/pimalaya/io-discovery) 驱动的**服务商发现**向导：Thunderbird Autoconfiguration、PACC 与 RFC 6186 SRV 查询
+- 支持多账户的 **TOML** 配置
+- 通过 `--json` 输出 **JSON**
+
+*Himalaya CLI 使用 [Rust](https://www.rust-lang.org/) 编写，并依赖 [cargo features](https://doc.rust-lang.org/cargo/reference/features.html) 启用或禁用功能。默认 feature 见 [`Cargo.toml`](./Cargo.toml#L18) 的 `features` 节，或 [docs.rs](https://docs.rs/crate/himalaya/latest/features)。*
+
+## 安装
+
+### 预编译二进制
+
+可使用 `install.sh` 安装 Himalaya CLI：
+
+*以 root 运行：*
+
+```
+curl -sSL https://raw.githubusercontent.com/pimalaya/himalaya/master/install.sh | sudo sh
+```
+
+*以普通用户运行：*
+
+```
+curl -sSL https://raw.githubusercontent.com/pimalaya/himalaya/master/install.sh | PREFIX=~/.local sh
+```
+
+上述命令会从 GitHub [releases](https://github.com/pimalaya/himalaya/releases) 安装最新二进制。
+
+若需要比最新 release 更新的版本，可查看 [releases](https://github.com/pimalaya/himalaya/actions/workflows/releases.yml) GitHub 工作流中的 *Artifacts* 部分，会有匹配你操作系统的预编译二进制。这些二进制由 `master` 分支构建。
+
+*此类二进制使用默认 cargo features 构建。若需要更多 feature，请改用其他安装方式。*
+
+### Cargo
+
+可使用 [cargo](https://doc.rust-lang.org/cargo/) 安装 Himalaya CLI：
+
+```
+cargo install himalaya --locked
+```
+
+仅启用 IMAP 支持：
+
+```
+cargo install himalaya --locked --no-default-features --features imap
+```
+
+也可使用 git 仓库获取更新（但稳定性较低）的版本：
+
+```
+cargo install --locked --git https://github.com/pimalaya/himalaya.git
+```
+
+### Arch Linux
+
+在 [Arch Linux](https://archlinux.org/) 上可通过社区仓库安装：
+
+```
+pacman -S himalaya
+```
+
+或通过 [用户仓库](https://aur.archlinux.org/)：
+
+```
+git clone https://aur.archlinux.org/himalaya-git.git
+cd himalaya-git
+makepkg -isc
+```
+
+若使用 [yay](https://github.com/Jguer/yay)，更简单：
+
+```
+yay -S himalaya-git
+```
+
+### Homebrew
+
+可使用 [Homebrew](https://brew.sh/) 安装：
+
+```
+brew install himalaya
+```
+
+注意：brew 与 cargo features 不兼容。若需要不同的 feature 组合，请改用其他安装方式。
+
+### Scoop
+
+可使用 [Scoop](https://scoop.sh/) 安装：
+
+```
+scoop install himalaya
+```
+
+### Fedora Linux/CentOS/RHEL
+
+在 [Fedora Linux](https://fedoraproject.org/)/CentOS/RHEL 上可通过 [COPR](https://copr.fedorainfracloud.org/coprs/atim/himalaya/) 仓库安装：
+
+```
+dnf copr enable atim/himalaya
+dnf install himalaya
+```
+
+### Nix
+
+可使用 [Nix](https://serokell.io/blog/what-is-nix) 安装：
+
+```
+nix-env -i himalaya
+```
+
+也可使用 git 仓库获取更新（但稳定性较低）的版本：
+
+```
+nix-env -if https://github.com/pimalaya/himalaya/archive/master.tar.gz
+```
+
+*或在源码树检出目录内：*
+
+```
+nix-env -if .
+```
+
+若已启用 [Flakes](https://nixos.wiki/wiki/Flakes)：
+
+```
+nix profile install github:pimalaya/himalaya
+```
+
+*或在源码树检出目录内：*
+
+```
+nix profile install
+```
+
+*也可不安装直接运行 Himalaya：*
+
+```
+nix run github:pimalaya/himalaya
+```
+
+### 源码
+
+```
+git clone https://github.com/pimalaya/himalaya
+cd himalaya
+nix develop --command cargo build --release
+```
+
+*二进制位于 `target/release` 目录。*
+
+## 配置
+
+直接运行 `himalaya`。未找到配置文件时，向导会提示输入账户名和邮箱地址，执行 [服务商发现](https://github.com/pimalaya/io-discovery)（PACC → Thunderbird Autoconfiguration → RFC 6186 SRV），用发现到的默认值填充 IMAP/SMTP（或 JMAP）提示，并将结果写入磁盘。
+
+之后可用 `himalaya account configure <name>` 重新配置账户。此模式下向导跳过发现：以现有值作为提示的默认值。
+
+也可手动编写配置：
+
+- 复制文档化的 [./config.sample.toml](./config.sample.toml)
+- 粘贴到以下之一：
+  - `$XDG_CONFIG_HOME/himalaya/config.toml`
+  - `$HOME/.config/himalaya/config.toml`
+  - `$HOME/.himalayarc`
+- 注释或取消注释你需要的选项
+
+…或通过 `-c <PATH>` / 设置 `HIMALAYA_CONFIG=<PATH>` 指定。可一次传入多个路径，用 `:` 分隔；第一个为基础配置，其余在其上深度合并。
+
+## 用法
+
+### 共享 API
+
+与后端无关的命令作用于账户配置的第一个后端，或通过 `-b/--backend` 选择的后端：
+
+```
+himalaya mailboxes list
+himalaya envelopes list -m INBOX --page 2
+himalaya envelopes search from alice and after 2026-01-01 order by date desc
+himalaya flags add -m INBOX --flag seen 1:3,5
+himalaya messages copy --from INBOX --to Archives 42
+himalaya attachments download -m INBOX 42
+```
+
+在 `[mailbox.alias]` 下配置了 `inbox` 别名后，`-m/--mailbox` 变为可选：共享命令会回退到该 id。例如 `[mailbox.alias] inbox = "INBOX"` 时，上述调用可简化为 `envelopes list --page 2`、`flags add --flag seen 1:3,5` 等。
+
+`envelopes list` 为按日期降序的普通分页。要筛选或排序，请使用 `envelopes search` 及尾部查询，支持 `date`、`after`、`from`、`to`、`subject`、`body`、`flag` 条件（用 `and`、`or`、`not` 组合，括号分组）以及 `order by date|from|to|subject [asc|desc]` 排序链。日期子句针对各后端的 `Date:` 头（发送时间）。
+
+共享接口是 IMAP、JMAP 与 Maildir 之间的严格最小公倍数子集。无法泛化的操作（邮箱角色、属性标志、JMAP 专用查询等）位于协议专用子命令下。
+
+### 协议专用 API
+
+每个后端在其子组下暴露完整原生 API：
+
+```
+himalaya imap mailboxes select INBOX
+himalaya imap mailboxes status INBOX
+himalaya imap mailboxes subscribe INBOX
+
+himalaya jmap mailboxes query --role drafts
+himalaya jmap identity get
+himalaya jmap vacation get
+
+himalaya maildir create Archives
+himalaya maildir messages save -m ~/Mail/example/Archives < message.eml
+
+himalaya smtp messages send < message.eml
+```
+
+`-b/--backend` 标志仅由共享命令消费；协议子命令始终使用各自的后端。
+
+### 撰写邮件
+
+内置的 `messages compose` / `reply` / `forward` 命令通过 CLI 标志覆盖简单场景：
+
+```
+himalaya messages compose --from me@example.org --to you@example.org \
+    --subject "Hello" --body "Hi!" --send
+```
+
+更丰富的撰写（多部分 MIME、MML 指令、签名/加密、编辑器驱动工作流等）可在 `[message.composer.*]` 中配置用户定义的 composer，并通过 `-with` 变体调用。例如配合 [`mml`](https://github.com/pimalaya/mml)：
+
+```toml
+[message.composer.mml]
+command = "mml compose"
+default = true
+```
+
+```
+himalaya messages compose-with
+himalaya messages reply-with -m INBOX 42 --send
+himalaya messages forward-with -m INBOX 42 --send
+himalaya messages mailto 'mailto:bob@example.org?subject=Hi&body=Hello'
+```
+
+`messages mailto <URI>` 解析 RFC 6068 `mailto:` URI（路径中的收件人列表，`to` / `cc` / `bcc` / `subject` / `body` 查询参数），构建预填这些头的 RFC 5322 草稿骨架，再通过 stdin 传给指定（或默认）composer 编辑。composer 输出经 `--save` / `--send` 路由，与其他 `-with` 变体相同。适合作为桌面 `mailto:` 处理程序。
+
+### 阅读邮件
+
+内置 `messages read` 使用 himalaya 默认格式化器渲染邮件。自定义渲染可在 `[message.reader.*]` 中声明 reader，并调用 `read-with`：
+
+```toml
+[message.reader.mml]
+command = "mml read"
+default = true
+```
+
+```
+himalaya messages read-with -m INBOX 42
+```
+
+### 复用会话
+
+默认每次调用都会建立新的 TCP+TLS+SASL 会话。要在多条命令间摊销握手开销，可将 himalaya 与 [`sirup`](https://github.com/pimalaya/sirup) 配合：`sirup` 通过 Unix 套接字暴露已认证的 IMAP/SMTP 会话，himalaya 可将 `imap.server` / `smtp.server` 指向该套接字。
+
+## 界面
+
+以下界面基于 Himalaya CLI 构建，以改善用户体验：
+
+- [pimalaya/himalaya-tui](https://github.com/pimalaya/himalaya-tui)：官方 TUI（积极开发中）
+- [pimalaya/himalaya-vim](https://github.com/pimalaya/himalaya-vim)：Vim 插件
+- [dantecatalfamo/himalaya-emacs](https://github.com/dantecatalfamo/himalaya-emacs)：Emacs 插件
+- [jns/himalaya](https://www.raycast.com/jns/himalaya)：Raycast 扩展
+- [openclaw/openclaw](https://github.com/openclaw/openclaw/blob/main/skills/himalaya/SKILL.md)：OpenClaw SKILL
+- [parisni/dfzf](https://github.com/parisni/dfzf)：dfzf 集成
+
+## 常见问题
+
+<details>
+  <summary>与 aerc、mutt 或 alpine 有何不同？</summary>
+
+  aerc、mutt 和 alpine 可归类为终端用户界面（TUI）。程序运行后，终端进入事件循环，通过按键与邮件交互。
+
+  Himalaya 是命令行界面（CLI）。没有事件循环：通过 shell 命令以无状态方式与邮件交互。
+
+  基于同一 Pimalaya 库的专用 TUI（[himalaya-tui](https://github.com/pimalaya/himalaya-tui)）正在积极开发中。
+</details>
+
+<details>
+  <summary>密钥如何解析？</summary>
+
+  每个 `*.passwd` / `*.password` / `*.token` 字段可接受原始字面量，或向 stdout 输出密钥的 shell 命令。原始形式便于测试，不应在生产环境使用：
+
+  ```toml
+  imap.sasl.plain.passwd.raw = "***"
+  imap.sasl.plain.passwd.command = "pass show example"
+  imap.sasl.plain.passwd.command = ["pass", "show", "example"]
+  ```
+
+  v2 已移除原生钥匙串支持。请将 [pimalaya/mimosa](https://github.com/pimalaya/mimosa)（或 `pass`、`secret-tool`、`gopass` 等）用作 `command`。
+</details>
+
+<details>
+  <summary>OAuth 2.0 如何处理？</summary>
+
+  v2 不内置 OAuth 流程。使用 [pimalaya/ortie](https://github.com/pimalaya/ortie)（或其他令牌代理）获取访问令牌，再将其作为向 stdout 返回令牌的 `command` 接入。JMAP 将 `jmap.auth.bearer.token.command` 指向代理；IMAP/SMTP 通过消费 command 来源密码的 SASL 机制传递 bearer。
+</details>
+
+<details>
+  <summary>向导如何发现 IMAP/SMTP/JMAP 配置？</summary>
+
+  向导在邮箱域名上依次运行三种发现机制；第一个非空结果生效：
+
+  1. **PACC** <sup>[draft-ietf-mailmaint-pacc-02](https://datatracker.ietf.org/doc/html/draft-ietf-mailmaint-pacc-02)</sup>：well-known JSON，对照 `_ua-auto-config` TXT 记录进行摘要校验。
+  2. **Thunderbird Autoconfiguration**：ISP main / well-known / ISPDB 查询，然后基于 MX 重试，再处理 `mailconf=<URL>` TXT 重定向。
+  3. **RFC 6186 SRV**：查询 `_imap._tcp`、`_imaps._tcp`、`_submission._tcp` 并组装为单一报告。
+
+  完整链路见 [io-discovery](https://github.com/pimalaya/io-discovery)。
+</details>
+
+<details>
+  <summary>如何调试 Himalaya CLI？</summary>
+
+  使用 `--log-level <level>`（别名 `--log`），`<level>` 为 `off`、`error`、`warn`、`info`、`debug`、`trace` 之一：
+
+  ```
+  himalaya --log trace mailboxes list
+  ```
+
+  未传递 `--log` 时会读取 `RUST_LOG` 环境变量，支持按目标筛选（见 [`env_logger` 文档](https://docs.rs/env_logger/latest/env_logger/#enabling-logging)）。`RUST_BACKTRACE=1` 可启用完整错误回溯。
+
+  日志写入 `stderr`，便于重定向到文件：
+
+  ```
+  himalaya --log trace mailboxes list 2>/tmp/himalaya.log
+  ```
+
+  也可通过 `--log-file <path>` 直接写入文件：
+
+  ```
+  himalaya --log trace --log-file /tmp/himalaya.log mailboxes list
+  ```
+</details>
+
+<details>
+  <summary>如何禁用彩色输出？</summary>
+
+  在环境中设置 `NO_COLOR=1`。
+</details>
+
+## 社区
+
+- 在 [Matrix](https://matrix.to/#/#pimalaya:matrix.org) 聊天
+- 在 [Mastodon](https://fosstodon.org/@pimalaya) 或 [RSS](https://fosstodon.org/@pimalaya.rss) 获取动态
+- 邮件联系 [pimalaya.org@posteo.net](mailto:pimalaya.org@posteo.net)
+
+## 赞助
+
+[![nlnet](https://nlnet.nl/logo/banner-160x60.png)](https://nlnet.nl/)
+
+特别感谢多年来为项目提供资金支持的 [NLnet 基金会](https://nlnet.nl/)与[欧盟委员会](https://www.ngi.eu/)：
+
+- 2022 → 2023：[NGI Assure](https://nlnet.nl/project/Himalaya/)
+- 2023 → 2024：[NGI Zero Entrust](https://nlnet.nl/project/Pimalaya/)
+- 2024 → 2026：[NGI Zero Core](https://nlnet.nl/project/Pimalaya-PIM/)
+- *2027 筹备中…*
+
+若你欣赏本项目，欢迎通过以下渠道捐赠：
+
+[![GitHub](https://img.shields.io/badge/-GitHub%20Sponsors-fafbfc?logo=GitHub%20Sponsors)](https://github.com/sponsors/soywod)
+[![Ko-fi](https://img.shields.io/badge/-Ko--fi-ff5e5a?logo=Ko-fi&logoColor=ffffff)](https://ko-fi.com/soywod)
+[![Buy Me a Coffee](https://img.shields.io/badge/-Buy%20Me%20a%20Coffee-ffdd00?logo=Buy%20Me%20A%20Coffee&logoColor=000000)](https://www.buymeacoffee.com/soywod)
+[![Liberapay](https://img.shields.io/badge/-Liberapay-f6c915?logo=Liberapay&logoColor=222222)](https://liberapay.com/soywod)
+[![thanks.dev](https://img.shields.io/badge/-thanks.dev-000000?logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQuMDk3IiBoZWlnaHQ9IjE3LjU5NyIgY2xhc3M9InctMzYgbWwtMiBsZzpteC0wIHByaW50Om14LTAgcHJpbnQ6aW52ZXJ0IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxwYXRoIGQ9Ik05Ljc4MyAxNy41OTdINy4zOThjLTEuMTY4IDAtMi4wOTItLjI5Ny0yLjc3My0uODktLjY4LS41OTMtMS4wMi0xLjQ2Mi0xLjAyLTIuNjA2di0xLjM0NmMwLTEuMDE4LS4yMjctMS43NS0uNjc4LTIuMTk1LS40NTItLjQ0Ni0xLjIzMi0uNjY5LTIuMzQtLjY2OUgwVjcuNzA1aC41ODdjMS4xMDggMCAxLjg4OC0uMjIyIDIuMzQtLjY2OC40NTEtLjQ0Ni42NzctMS4xNzcuNjc3LTIuMTk1VjMuNDk2YzAtMS4xNDQuMzQtMi4wMTMgMS4wMjEtMi42MDZDNS4zMDUuMjk3IDYuMjMgMCA3LjM5OCAwaDIuMzg1djEuOTg3aC0uOTg1Yy0uMzYxIDAtLjY4OC4wMjctLjk4LjA4MmExLjcxOSAxLjcxOSAwIDAgMC0uNzM2LjMwN2MtLjIwNS4xNTYtLjM1OC4zODQtLjQ2LjY4Mi0uMTAzLjI5OC0uMTU0LjY4Mi0uMTU0IDEuMTUxVjUuMjNjMCAuODY3LS4yNDkgMS41ODYtLjc0NSAyLjE1NS0uNDk3LjU2OS0xLjE1OCAxLjAwNC0xLjk4MyAxLjMwNXYuMjE3Yy44MjUuMyAxLjQ4Ni43MzYgMS45ODMgMS4zMDUuNDk2LjU3Ljc0NSAxLjI4Ny43NDUgMi4xNTR2MS4wMjFjMCAuNDcuMDUxLjg1NC4xNTMgMS4xNTIuMTAzLjI5OC4yNTYuNTI1LjQ2MS42ODIuMTkzLjE1Ny40MzcuMjYuNzMyLjMxMi4yOTUuMDUuNjIzLjA3Ni45ODQuMDc2aC45ODVabTE0LjMxNC03LjcwNmgtLjU4OGMtMS4xMDggMC0xLjg4OC4yMjMtMi4zNC42NjktLjQ1LjQ0NS0uNjc3IDEuMTc3LS42NzcgMi4xOTVWMTQuMWMwIDEuMTQ0LS4zNCAyLjAxMy0xLjAyIDIuNjA2LS42OC41OTMtMS42MDUuODktMi43NzQuODloLTIuMzg0di0xLjk4OGguOTg0Yy4zNjIgMCAuNjg4LS4wMjcuOTgtLjA4LjI5Mi0uMDU1LjUzOC0uMTU3LjczNy0uMzA4LjIwNC0uMTU3LjM1OC0uMzg0LjQ2LS42ODIuMTAzLS4yOTguMTU0LS42ODIuMTU0LTEuMTUydi0xLjAyYzAtLjg2OC4yNDgtMS41ODYuNzQ1LTIuMTU1LjQ5Ny0uNTcgMS4xNTgtMS4wMDQgMS45ODMtMS4zMDV2LS4yMTdjLS44MjUtLjMwMS0xLjQ4Ni0uNzM2LTEuOTgzLTEuMzA1LS40OTctLjU3LS43NDUtMS4yODgtLjc0NS0yLjE1NXYtMS4wMmMwLS40Ny0uMDUxLS44NTQtLjE1NC0xLjE1Mi0uMTAyLS4yOTgtLjI1Ni0uNTI2LS40Ni0uNjgyYTEuNzE5IDEuNzE5IDAgMCAwLS43MzctLjMwNyA1LjM5NSA1LjM5NSAwIDAgMC0uOTgtLjA4MmgtLjk4NFYwaDIuMzg0YzEuMTY5IDAgMi4wOTMuMjk3IDIuNzc0Ljg5LjY4LjU5MyAxLjAyIDEuNDYyIDEuMDIgMi42MDZ2MS4zNDZjMCAxLjAxOC4yMjYgMS43NS42NzggMi4xOTUuNDUxLjQ0NiAxLjIzMS42NjggMi4zNC42NjhoLjU4N3oiIGZpbGw9IiNmZmYiLz48L3N2Zz4=)](https://thanks.dev/soywod)
+[![PayPal](https://img.shields.io/badge/-PayPal-0079c1?logo=PayPal&logoColor=ffffff)](https://www.paypal.com/paypalme/soywod)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@
     <a href="https://matrix.to/#/#pimalaya:matrix.org"><img alt="Matrix" src="https://img.shields.io/badge/chat-%23pimalaya-blue?style=flat&logo=matrix&logoColor=white"/></a>
     <a href="https://fosstodon.org/@pimalaya"><img alt="Mastodon" src="https://img.shields.io/badge/news-%40pimalaya-blue?style=flat&logo=mastodon&logoColor=white"/></a>
   </p>
+  <p>
+    <strong>Languages:</strong>
+    <a href="README.md">English</a> ·
+    <a href="README-ZH.md">中文</a> ·
+    <a href="README-ES.md">Español</a> ·
+    <a href="README-FR.md">Français</a> ·
+    <a href="README-PT.md">Português</a> ·
+    <a href="README-RU.md">Русский</a> ·
+    <a href="README-DE.md">Deutsch</a>
+  </p>
 </div>
 
 ```


### PR DESCRIPTION
## Summary

- Add README translations in Chinese, Spanish, French, Portuguese, Russian, and German
- Add a unified language switcher to all README variants

## Changes

| File | Language |
|------|----------|
| `README-ZH.md` | 中文 |
| `README-ES.md` | Español |
| `README-FR.md` | Français |
| `README-PT.md` | Português |
| `README-RU.md` | Русский |
| `README-DE.md` | Deutsch |
| `README.md` | Updated language navigation |

Each translation preserves the full structure of the English README, including installation guides for all platforms, configuration wizard docs, usage examples, and FAQ sections. Commands, TOML snippets, and URLs are kept unchanged.

## Test plan

- [ ] Verify language switcher links work across all README files
- [ ] Confirm code blocks and installation commands render correctly
- [ ] Spot-check translation accuracy for configuration and FAQ sections