### PR TITLE
feat(imap): add config option for IMAP ID (RFC 2971)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -418,6 +418,68 @@ pub struct ImapConfig {
     /// to advertise the ANONYMOUS mechanism explicitly, set
     /// `sasl.anonymous = {}`.
     pub sasl: Option<SaslConfig>,
+
+    /// IMAP extensions configuration (RFC 2971 ID, etc.).
+    #[serde(default)]
+    pub extensions: ImapExtensionsConfig,
+}
+
+/// IMAP extensions configuration.
+///
+/// Controls optional IMAP extensions such as RFC 2971 (ID command).
+/// Each extension is nested under its RFC or feature name.
+///
+/// # Example
+///
+/// ```toml
+/// [accounts.myaccount.imap.extensions.id]
+/// send-after-auth = true
+/// name = "MyClient"           # optional override
+/// version = "1.0"             # optional override
+/// ```
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct ImapExtensionsConfig {
+    /// RFC 2971 ID command configuration. When `send-after-auth`
+    /// is true, an IMAP ID command is sent after authentication.
+    /// The field values are optional overrides; when omitted,
+    /// sensible defaults (name = "Himalaya", vendor = "Pimalaya",
+    /// version = `CARGO_PKG_VERSION`, support-email =
+    /// "pimalaya.org@posteo.net") are used.
+    #[serde(default)]
+    pub id: ImapIdConfig,
+}
+
+/// RFC 2971 IMAP ID command configuration.
+///
+/// Controls whether and how the IMAP ID command is sent after
+/// authentication. Some servers (e.g. NetEase 163) require this
+/// before allowing mailbox SELECT.
+///
+/// When `send-after-auth` is `false` (the default), no ID command
+/// is sent, preserving the behavior of previous versions.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct ImapIdConfig {
+    /// Whether to send the IMAP ID command after authentication.
+    #[serde(default)]
+    pub send_after_auth: bool,
+
+    /// Client name advertised in the ID command.
+    /// Defaults to `"Himalaya"`.
+    pub name: Option<String>,
+
+    /// Client version advertised in the ID command.
+    /// Defaults to `CARGO_PKG_VERSION` at compile time.
+    pub version: Option<String>,
+
+    /// Client vendor advertised in the ID command.
+    /// Defaults to `"Pimalaya"`.
+    pub vendor: Option<String>,
+
+    /// Support email advertised in the ID command.
+    /// Defaults to `"pimalaya.org@posteo.net"`.
+    pub support_email: Option<String>,
 }
 
 /// Maildir configuration.

--- a/src/imap/client.rs
+++ b/src/imap/client.rs
@@ -29,6 +29,7 @@ use std::{
 
 use anyhow::{Result, anyhow};
 use io_imap::client::ImapClientStd as Inner;
+use io_imap::types::core::{IString, NString};
 use pimalaya_config::toml::TomlConfig;
 use pimalaya_stream::{sasl::Sasl, std::stream::StreamStd, tls::Tls};
 use url::Url;
@@ -48,7 +49,58 @@ impl ImapClient {
         tls.rustls.alpn = vec!["imap".into()];
         let sasl: Option<Sasl> = config.sasl.map(Sasl::try_from).transpose()?;
         let server = parse_imap_server(&config.server)?;
-        let inner = Inner::<StreamStd>::connect(&server, &tls, config.starttls, sasl)?;
+        let mut inner = Inner::<StreamStd>::connect(&server, &tls, config.starttls, sasl)?;
+
+        // Send IMAP ID (RFC 2971) after authentication when configured.
+        // Some servers (e.g. NetEase 163) require this before allowing
+        // mailbox SELECT.
+        if config.extensions.id.send_after_auth {
+            let name = config
+                .extensions
+                .id
+                .name
+                .clone()
+                .unwrap_or_else(|| "Himalaya".into());
+            let version = config
+                .extensions
+                .id
+                .version
+                .clone()
+                .unwrap_or_else(|| env!("CARGO_PKG_VERSION").into());
+            let vendor = config
+                .extensions
+                .id
+                .vendor
+                .clone()
+                .unwrap_or_else(|| "Pimalaya".into());
+            let support_email = config
+                .extensions
+                .id
+                .support_email
+                .clone()
+                .unwrap_or_else(|| "pimalaya.org@posteo.net".into());
+
+            let id_fields: Vec<(IString<'static>, NString<'static>)> = [
+                ("name", NString::try_from(name.into_bytes()).unwrap()),
+                (
+                    "version",
+                    NString::try_from(version.into_bytes()).unwrap(),
+                ),
+                ("vendor", NString::try_from(vendor.into_bytes()).unwrap()),
+                (
+                    "support-email",
+                    NString::try_from(support_email.into_bytes()).unwrap(),
+                ),
+            ]
+            .into_iter()
+            .map(|(k, v)| (IString::try_from(k).unwrap(), v))
+            .collect();
+
+            if let Err(err) = inner.id(Some(id_fields)) {
+                log::warn!("IMAP ID command failed (non-fatal): {err}");
+            }
+        }
+
         Ok(Self { inner, account })
     }
 }

--- a/src/shared/client.rs
+++ b/src/shared/client.rs
@@ -82,14 +82,58 @@ impl EmailClient {
         if !configured && backend.allows_imap() {
             if let Some(imap_config) = account_config.imap.take() {
                 use io_imap::client::ImapClientStd;
+                use io_imap::types::core::{IString, NString};
                 use pimalaya_stream::{sasl::Sasl, std::stream::StreamStd, tls::Tls};
 
                 let mut tls: Tls = imap_config.tls.into();
                 tls.rustls.alpn = vec!["imap".into()];
                 let sasl: Option<Sasl> = imap_config.sasl.map(Sasl::try_from).transpose()?;
                 let server = crate::imap::client::parse_imap_server(&imap_config.server)?;
-                let client =
+                let mut client =
                     ImapClientStd::<StreamStd>::connect(&server, &tls, imap_config.starttls, sasl)?;
+
+                // Send IMAP ID (RFC 2971) after authentication when configured.
+                // Some servers (e.g. NetEase 163) require this before allowing
+                // mailbox SELECT.
+                if imap_config.extensions.id.send_after_auth {
+                    let id_cfg = &imap_config.extensions.id;
+                    let name = id_cfg
+                        .name
+                        .clone()
+                        .unwrap_or_else(|| "Himalaya".into());
+                    let version = id_cfg
+                        .version
+                        .clone()
+                        .unwrap_or_else(|| env!("CARGO_PKG_VERSION").into());
+                    let vendor = id_cfg
+                        .vendor
+                        .clone()
+                        .unwrap_or_else(|| "Pimalaya".into());
+                    let support_email = id_cfg
+                        .support_email
+                        .clone()
+                        .unwrap_or_else(|| "pimalaya.org@posteo.net".into());
+
+                    let id_fields: Vec<(IString<'static>, NString<'static>)> = [
+                        ("name", NString::try_from(name.into_bytes()).unwrap()),
+                        (
+                            "version",
+                            NString::try_from(version.into_bytes()).unwrap(),
+                        ),
+                        ("vendor", NString::try_from(vendor.into_bytes()).unwrap()),
+                        (
+                            "support-email",
+                            NString::try_from(support_email.into_bytes()).unwrap(),
+                        ),
+                    ]
+                    .into_iter()
+                    .map(|(k, v)| (IString::try_from(k).unwrap(), v))
+                    .collect();
+
+                    if let Err(err) = client.id(Some(id_fields)) {
+                        log::warn!("IMAP ID command failed (non-fatal): {err}");
+                    }
+                }
 
                 inner = inner.with_imap(client);
                 configured = true;

--- a/src/wizard/account.rs
+++ b/src/wizard/account.rs
@@ -49,6 +49,7 @@ pub fn imap_to_config(w: WizardImapConfig) -> Result<ImapConfig> {
         tls: Default::default(),
         starttls,
         sasl,
+        extensions: Default::default(),
     })
 }
 


### PR DESCRIPTION
Add an IMAP extensions configuration system under `imap.extensions.*`, starting with RFC 2971 ID command support.

## Problem
Some IMAP servers (e.g. NetEase 163) require clients to send an IMAP ID command (RFC 2971) after authentication, before they allow mailbox SELECT. Without it, commands fail with `NO SELECT Unsafe Login`.

## Solution

Add a new `[accounts.<name>.imap.extensions.id]` config block:

```toml
[accounts.myaccount.imap.extensions.id]
send-after-auth = true
# optional overrides (when omitted, sensible defaults are used):
# name = "MyClient"
# version = "1.0"
# vendor = "MyOrg"
# support-email = "support@myorg.com"
```

When `send-after-auth` is `true`, an IMAP ID command is sent after authentication. The field values are optional overrides; when omitted, compiled-in defaults (name = "Himalaya", version = `CARGO_PKG_VERSION`, vendor = "Pimalaya", support-email = "pimalaya.org@posteo.net") are used.

## Backward Compatibility

`send-after-auth` defaults to `false`, preserving the previous behavior for all existing configurations.

## Implementation

- `src/config.rs`: Added `ImapExtensionsConfig` and `ImapIdConfig` structs, `extensions` field on `ImapConfig`
- `src/imap/client.rs`: Config-driven IMAP ID in `ImapClient::new()`
- `src/shared/client.rs`: Config-driven IMAP ID in `EmailClient` (shared subcommands path)
- `src/wizard/account.rs`: Initialize `extensions` with defaults

Closes #676