### PR TITLE
fix(nix): rename buildFeatures → withFeatures

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -19,8 +19,8 @@ pimalaya.mkDefault (
       }:
       (pkgs.callPackage "${nixpkgs}/pkgs/by-name/hi/himalaya/package.nix" {
         inherit lib rustPlatform;
-        buildNoDefaultFeatures = !defaultFeatures;
-        buildFeatures = lib.splitString "," features;
+        withNoDefaultFeatures = !defaultFeatures;
+        withFeatures = lib.splitString "," features;
       })
       # HACK: needed until new derivation available on nixpkgs's
       # master branch


### PR DESCRIPTION
`default.nix` calls nixpkgs's himalaya `package.nix` with
`buildFeatures` / `buildNoDefaultFeatures`. nixpkgs renamed those args
to `withFeatures` / `withNoDefaultFeatures` and now prints a deprecation
warning every time the old names are used:

    evaluation warning: buildFeatures is deprecated in favour of
      withFeatures and will be removed in the next release

This PR just renames them. No behavior change — nixpkgs still accepts
both names today, this only silences the warning ahead of the eventual
removal.