### PR TITLE
fix(imap): Gmail-compatible search fallback + docs from #699

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,17 +192,19 @@ Accounts can be (re)configured later with `himalaya account configure <name>`. T
 Backend-agnostic commands operate on the account's first configured backend, or the one selected with `-b/--backend`:
 
 ```
-himalaya mailboxes list
-himalaya envelopes list -m INBOX --page 2
-himalaya envelopes search from alice and after 2026-01-01 order by date desc
-himalaya flags add -m INBOX --flag seen 1:3,5
-himalaya messages copy --from INBOX --to Archives 42
-himalaya attachments download -m INBOX 42
+himalaya mailbox list
+himalaya envelope list -m INBOX --page 2
+himalaya envelope search from alice and after 2026-01-01 order by date desc
+himalaya flag add -m INBOX --flag seen 1:3,5
+himalaya message copy --from INBOX --to Archives 42
+himalaya attachment download -m INBOX 42
 ```
 
-When the `inbox` alias is configured under `[mailbox.alias]`, `-m/--mailbox` becomes optional: shared commands fall back to that id. With `[mailbox.alias] inbox = "INBOX"`, the calls above shorten to `envelopes list --page 2`, `flags add --flag seen 1:3,5`, etc.
+When the `inbox` alias is configured under `[mailbox.alias]`, `-m/--mailbox` becomes optional: shared commands fall back to that id. With `[mailbox.alias] inbox = "INBOX"`, the calls above shorten to `envelope list --page 2`, `flag add --flag seen 1:3,5`, etc.
 
-`envelopes list` is plain pagination, ordered by date descending. To filter or sort, use `envelopes search` with a trailing query covering `date`, `after`, `from`, `to`, `subject`, `body`, `flag` conditions (combined with `and`, `or`, `not`, grouped with parens) and an `order by date|from|to|subject [asc|desc]` sort chain. Date clauses target the `Date:` header (sent-at) on every backend.
+`envelope list` is plain pagination, ordered by date descending. To filter or sort, use `envelope search` with a trailing query covering `date`, `after`, `from`, `to`, `subject`, `body`, `flag` conditions (combined with `and`, `or`, `not`, grouped with parens) and an `order by date|from|to|subject [asc|desc]` sort chain. Date clauses target the `Date:` header (sent-at) on every backend. The full grammar lives in `himalaya envelope search --help`, which is the source of truth for the query DSL.
+
+The query DSL is himalaya's own and compiles to each backend's native search: provider-specific operators (Gmail's `in:`/`label:` syntax, `X-GM-RAW`, …) are not supported. On IMAP the search runs server-side as `UID SORT`; servers that lack the `SORT` capability (notably Gmail) are detected automatically and himalaya degrades to a plain `UID SEARCH` — without `order by` the results come back newest-first (arrival order, page fetched only), with `order by` every match is fetched and sorted client-side, which can be slow on very large mailboxes.
 
 The shared surface is a strict least-common-denominator subset across IMAP, JMAP and Maildir. Operations that do not generalize (mailbox roles, attribute flags, JMAP-specific queries…) live under the protocol-specific subcommands.
 
@@ -211,9 +213,9 @@ The shared surface is a strict least-common-denominator subset across IMAP, JMAP
 Each backend exposes its full native API under its own subgroup:
 
 ```
-himalaya imap mailboxes select INBOX
-himalaya imap mailboxes status INBOX
-himalaya imap mailboxes subscribe INBOX
+himalaya imap mailbox select INBOX
+himalaya imap mailbox status INBOX
+himalaya imap mailbox subscribe INBOX
 
 himalaya jmap mailboxes query --role drafts
 himalaya jmap identity get
@@ -229,25 +231,42 @@ The `-b/--backend` flag is only consumed by the shared commands; protocol subcom
 
 ### Composing messages
 
-The built-in `messages compose` / `reply` / `forward` commands cover simple cases via CLI flags:
+The built-in `message compose` / `reply` / `forward` commands cover simple cases via CLI flags:
 
 ```
-himalaya messages compose --from me@example.org --to you@example.org \
+himalaya message compose --from me@example.org --to you@example.org \
     --subject "Hello" --body "Hi!" --send
 ```
 
-For richer composition (multipart MIME, MML directives, signing/encryption, editor-driven workflows), chain a standalone composer such as [mml](https://github.com/pimalaya/mml) into `messages send` / `messages add` through a tempfile or bash/zsh process substitution:
+For richer composition (multipart MIME, MML directives, signing/encryption, editor-driven workflows), chain a standalone composer such as [mml](https://github.com/pimalaya/mml) into `message send` / `message add` through a tempfile or bash/zsh process substitution:
 
 ```sh
 # Explicit tempfile, works in plain POSIX sh
-mml compose /tmp/draft.eml && himalaya messages send /tmp/draft.eml
+mml compose /tmp/draft.eml && himalaya message send /tmp/draft.eml
 
 # Bash / zsh process substitution, single command, no tempfile
-mml compose >(himalaya messages send)
-himalaya messages read 42 | mml reply >(himalaya messages send)
+mml compose >(himalaya message send)
+himalaya message read 42 | mml reply >(himalaya message send)
 ```
 
-The path-arg or process-substitution forms keep the composer's stdout connected to the terminal, so any `$EDITOR` it spawns sees a real tty. The bare-pipe form (`mml compose | himalaya messages send`) hangs because the editor inherits a pipe on its stdout.
+The path-arg or process-substitution forms keep the composer's stdout connected to the terminal, so any `$EDITOR` it spawns sees a real tty. The bare-pipe form (`mml compose | himalaya message send`) hangs because the editor inherits a pipe on its stdout.
+
+A prepared RFC 5322 file can also be staged as a draft instead of sent right away — handy for "compose, review in another client, then send" workflows:
+
+```sh
+himalaya message add -m drafts --flag draft < message.eml  # save as draft
+himalaya message send --save sent < message.eml            # send + keep a copy
+```
+
+Both `-m`/`--save` values are resolved through the account's `[mailbox.alias]` map.
+
+### Reading messages
+
+`himalaya message read <ID>` renders headers and text bodies; `--raw` dumps the original RFC 5322 bytes; `--json` emits the parsed message. A few behaviours worth knowing, especially when scripting:
+
+- Reading is side-effect-free: messages are fetched with `BODY.PEEK`, so `message read` never sets `\Seen`. Mark explicitly with `flag add --flag seen <ID>`.
+- Ids are per-mailbox (IMAP UID, JMAP email id or Maildir filename id): the same message gets a new id when copied or moved. The `message-id` field exposed in `--json` envelope output is the stable cross-mailbox key.
+- Every command accepts `--json`; envelope listings serialize as `{"envelopes": [{"id", "message-id", "flags": [{"raw", "iana"}], "subject", "from": [{"name", "email"}], "to", "date", "size", "has-attachment"}]}`.
 
 ### Re-using sessions
 
@@ -314,7 +333,7 @@ Himalaya CLI is one of several front-ends to the Pimalaya libraries:
   Use `--log-level <level>` (alias `--log`) where `<level>` is one of `off`, `error`, `warn`, `info`, `debug`, `trace`:
 
   ```
-  himalaya --log trace mailboxes list
+  himalaya --log trace mailbox list
   ```
 
   The `RUST_LOG` environment variable is consulted when `--log` is not passed, and supports per-target filters (see the [`env_logger` documentation](https://docs.rs/env_logger/latest/env_logger/#enabling-logging)). `RUST_BACKTRACE=1` enables full error backtraces.
@@ -322,13 +341,13 @@ Himalaya CLI is one of several front-ends to the Pimalaya libraries:
   Logs are written to `stderr`, so they can be redirected easily to a file:
 
   ```
-  himalaya --log trace mailboxes list 2>/tmp/himalaya.log
+  himalaya --log trace mailbox list 2>/tmp/himalaya.log
   ```
 
   You can also send logs straight to a file via `--log-file <path>`:
 
   ```
-  himalaya --log trace --log-file /tmp/himalaya.log mailboxes list
+  himalaya --log trace --log-file /tmp/himalaya.log mailbox list
   ```
 </details>
 

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -120,6 +120,13 @@
 #mailbox.alias.drafts = "[Gmail]/Drafts"
 #mailbox.alias.trash = "[Gmail]/Trash"
 
+# Gmail notes: every Gmail label shows up as a top-level IMAP mailbox, and the
+# special mailboxes live under the `[Gmail]/` prefix — quote them in the shell
+# (`-m "[Gmail]/Drafts"`) or reach them through an alias. The archive
+# containing every message is `[Gmail]/All Mail`; aliasing it makes "search
+# everything" one flag away (`himalaya envelope search -m archive ...`):
+#mailbox.alias.archive = "[Gmail]/All Mail"
+
 # --------------------------------------------------------------------------------
 # Account config
 # --------------------------------------------------------------------------------
@@ -180,6 +187,10 @@ imap.server = "example.com"
 
 # SASL PLAIN
 # https://datatracker.ietf.org/doc/html/rfc4616
+#
+# Gmail does not accept the account password over SASL PLAIN: generate an app
+# password (https://myaccount.google.com/apppasswords, requires 2-step
+# verification) and feed it through `password.command` or `password.raw`.
 imap.sasl.plain.username = "user@example.com"
 imap.sasl.plain.password.raw = "***"
 #imap.sasl.plain.password.command = "pass show example"

--- a/src/shared/envelope/mod.rs
+++ b/src/shared/envelope/mod.rs
@@ -1,3 +1,5 @@
 pub mod cli;
 pub mod list;
 pub mod search;
+#[cfg(feature = "imap")]
+pub mod search_fallback;

--- a/src/shared/envelope/search.rs
+++ b/src/shared/envelope/search.rs
@@ -79,13 +79,30 @@ impl EnvelopeSearchCommand {
         let mailbox = self.mailbox.resolve(account)?;
         let query = parse_query(self.query.as_deref());
 
-        let envelopes = client.search_envelopes(
+        let envelopes = match client.search_envelopes(
             &mailbox,
             query.as_ref(),
             page,
             page_size,
             self.has_attachment,
-        )?;
+        ) {
+            // Servers without the SORT capability (e.g. Gmail) reject
+            // the UID SORT the shared search is built on; rerun as a
+            // plain UID SEARCH on the same session.
+            #[cfg(feature = "imap")]
+            Err(err) if super::search_fallback::applies(&err) && client.imap.is_some() => {
+                let imap = client.imap.as_mut().expect("checked in guard");
+                super::search_fallback::search(
+                    imap,
+                    &mailbox,
+                    query.as_ref(),
+                    page,
+                    page_size,
+                    self.has_attachment,
+                )?
+            }
+            res => res?,
+        };
 
         let envelopes = Envelopes {
             preset: account.table_preset().to_string(),

--- a/src/shared/envelope/search_fallback.rs
+++ b/src/shared/envelope/search_fallback.rs
@@ -1,0 +1,445 @@
+//! UID SEARCH fallback for IMAP servers without the RFC 5256 SORT
+//! extension (notably Gmail, which rejects `UID SORT` with `BAD
+//! Unknown command`).
+//!
+//! The shared `envelope search` command normally goes through
+//! io-email's `ImapEnvelopeSearch` coroutine, which always issues
+//! `UID SORT` — even when the query carries no `order by` clause
+//! (the sort then defaults to `REVERSE DATE`). On servers that do
+//! not advertise the SORT capability this fails wholesale.
+//!
+//! This module reruns the same filter as a plain `UID SEARCH`
+//! (RFC 3501) on the already-authenticated session:
+//!
+//! - without `order by`, matching UIDs are ordered newest-first
+//!   (descending UID, i.e. mailbox arrival order — an approximation
+//!   of the `REVERSE DATE` default) and only the requested page is
+//!   fetched;
+//! - with `order by`, every matching envelope is fetched (in chunks)
+//!   and sorted client-side before pagination, mirroring what v1 did.
+//!
+//! The FETCH→[`Envelope`] conversion mirrors io-email's private
+//! `envelope_from`; the durable home for this whole fallback is
+//! io-email's search coroutine itself, at which point this module
+//! can be deleted.
+
+use std::{cmp::Ordering, collections::BTreeMap, num::NonZeroU32, str::from_utf8};
+
+use anyhow::{Context, Result, anyhow};
+use chrono::{DateTime, FixedOffset};
+use io_email::address::Address;
+use io_email::{
+    client::EmailClientStdError,
+    envelope::{
+        imap::search::ImapEnvelopeSearchError,
+        types::{Envelope, normalize_message_id},
+    },
+    flag::types::{Flag, IanaFlag},
+    imap::{
+        client::{ImapClientError, ImapClientStd},
+        convert::parse_mailbox,
+    },
+    search::{
+        filter::query::SearchEmailsFilterQuery,
+        query::SearchEmailsQuery,
+        sort::query::{SearchEmailsSorter, SearchEmailsSorterKind, SearchEmailsSorterOrder},
+    },
+};
+use io_imap::{
+    rfc3501::{
+        fetch::{ImapMessageFetch, ImapMessageFetchOptions},
+        search::{ImapMessageSearch, ImapMessageSearchOptions},
+        select::{ImapMailboxSelect, ImapMailboxSelectOptions},
+    },
+    rfc5256::sort::ImapMailboxSortError,
+    types::{
+        body::BodyStructure,
+        core::{AString, Atom, Vec1},
+        datetime::NaiveDate as ImapNaiveDate,
+        envelope::Address as ImapAddress,
+        fetch::{MacroOrMessageDataItemNames, MessageDataItem, MessageDataItemName},
+        flag::FlagFetch,
+        search::SearchKey,
+        sequence::SequenceSet,
+    },
+};
+use log::debug;
+use rfc2047_decoder::{Decoder, RecoverStrategy};
+
+/// UIDs per FETCH round-trip when the whole match set is needed for
+/// client-side sorting.
+const FETCH_CHUNK: usize = 500;
+
+/// Whether `err` is the server actively refusing `UID SORT` (tagged
+/// NO/BAD), i.e. the case this fallback exists for. Transport-level
+/// failures keep bubbling up unchanged.
+pub fn applies(err: &EmailClientStdError) -> bool {
+    matches!(
+        err,
+        EmailClientStdError::Imap(ImapClientError::EnvelopeSearch(
+            ImapEnvelopeSearchError::Sort(
+                ImapMailboxSortError::No(_) | ImapMailboxSortError::Bad(_)
+            )
+        ))
+    )
+}
+
+/// Reruns the search as `SELECT` + `UID SEARCH` + paged `UID FETCH`
+/// on the same session. See the module docs for ordering semantics.
+pub fn search(
+    imap: &mut ImapClientStd,
+    mailbox: &str,
+    query: Option<&SearchEmailsQuery>,
+    page: Option<u32>,
+    page_size: Option<u32>,
+    with_attachment: bool,
+) -> Result<Vec<Envelope>> {
+    debug!("server lacks SORT: falling back to UID SEARCH for mailbox {mailbox}");
+
+    let mbox = parse_mailbox(mailbox).map_err(|err| anyhow!("invalid IMAP mailbox `{}`", err.0))?;
+    imap.inner
+        .run(ImapMailboxSelect::new(
+            mbox,
+            ImapMailboxSelectOptions::default(),
+        ))
+        .context("cannot select mailbox for UID SEARCH fallback")?;
+
+    let criteria = match query.and_then(|q| q.filter.as_ref()) {
+        None => Vec1::from(SearchKey::All),
+        Some(filter) => Vec1::from(convert_filter(filter)?),
+    };
+    let mut uids: Vec<u32> = imap
+        .inner
+        .run(ImapMessageSearch::new(
+            criteria,
+            ImapMessageSearchOptions { uid: true },
+        ))
+        .context("cannot run UID SEARCH fallback")?
+        .into_iter()
+        .map(NonZeroU32::get)
+        .collect();
+
+    let sorters = query.and_then(|q| q.sort.as_deref()).unwrap_or_default();
+
+    if sorters.is_empty() {
+        // Newest-first by arrival order, fetch the requested page only.
+        uids.sort_unstable_by(|a, b| b.cmp(a));
+        let uid_page = paginate(&uids, page, page_size);
+        let envelopes = fetch_envelopes(imap, &uid_page, with_attachment)?;
+        Ok(reorder(envelopes, &uid_page))
+    } else {
+        // Client-side sort needs every matching envelope.
+        let mut envelopes = Vec::with_capacity(uids.len());
+        for chunk in uids.chunks(FETCH_CHUNK) {
+            envelopes.extend(fetch_envelopes(imap, chunk, with_attachment)?.into_values());
+        }
+        envelopes.sort_by(|a, b| compare(a, b, sorters));
+        let page = paginate(&envelopes, page, page_size);
+        Ok(page)
+    }
+}
+
+/// Slices `items` for `(page, page_size)`; `None` page size means
+/// everything.
+fn paginate<T: Clone>(items: &[T], page: Option<u32>, page_size: Option<u32>) -> Vec<T> {
+    let Some(size) = page_size.map(|n| n as usize).filter(|n| *n > 0) else {
+        return items.to_vec();
+    };
+    let start = ((page.unwrap_or(1).max(1) - 1) as usize).saturating_mul(size);
+    if start >= items.len() {
+        return Vec::new();
+    }
+    let end = start.saturating_add(size).min(items.len());
+    items[start..end].to_vec()
+}
+
+/// `UID FETCH` for the given UIDs, keyed back by UID.
+fn fetch_envelopes(
+    imap: &mut ImapClientStd,
+    uids: &[u32],
+    with_attachment: bool,
+) -> Result<BTreeMap<u32, Envelope>> {
+    if uids.is_empty() {
+        return Ok(BTreeMap::new());
+    }
+
+    let uid_str = uids
+        .iter()
+        .map(u32::to_string)
+        .collect::<Vec<_>>()
+        .join(",");
+    let sequence_set: SequenceSet = uid_str
+        .as_str()
+        .try_into()
+        .map_err(|_| anyhow!("invalid IMAP UID set `{uid_str}`"))?;
+
+    let data = imap
+        .inner
+        .run(ImapMessageFetch::new(
+            sequence_set,
+            build_item_names(with_attachment),
+            ImapMessageFetchOptions {
+                uid: true,
+                ..Default::default()
+            },
+        ))
+        .context("cannot fetch envelopes for UID SEARCH fallback")?;
+
+    Ok(data
+        .into_iter()
+        .map(|(seq, items)| {
+            let items = items.into_inner();
+            let uid = items.iter().find_map(|item| match item {
+                MessageDataItem::Uid(u) => Some(u.get()),
+                _ => None,
+            });
+            let env = envelope_from(seq.get(), items);
+            (uid.unwrap_or_else(|| seq.get()), env)
+        })
+        .collect())
+}
+
+/// Reorders fetched envelopes into the requested UID order, dropping
+/// UIDs the server skipped.
+fn reorder(mut by_uid: BTreeMap<u32, Envelope>, order: &[u32]) -> Vec<Envelope> {
+    order.iter().filter_map(|u| by_uid.remove(u)).collect()
+}
+
+/// Left-to-right sorter chain comparison; ties fall through to the
+/// next sorter.
+fn compare(a: &Envelope, b: &Envelope, sorters: &[SearchEmailsSorter]) -> Ordering {
+    for SearchEmailsSorter(kind, order) in sorters {
+        let ord = match kind {
+            SearchEmailsSorterKind::Date => a.date.cmp(&b.date),
+            SearchEmailsSorterKind::From => address_key(&a.from).cmp(&address_key(&b.from)),
+            SearchEmailsSorterKind::To => address_key(&a.to).cmp(&address_key(&b.to)),
+            SearchEmailsSorterKind::Subject => {
+                a.subject.to_lowercase().cmp(&b.subject.to_lowercase())
+            }
+        };
+        let ord = match order {
+            SearchEmailsSorterOrder::Ascending => ord,
+            SearchEmailsSorterOrder::Descending => ord.reverse(),
+        };
+        if ord != Ordering::Equal {
+            return ord;
+        }
+    }
+    Ordering::Equal
+}
+
+fn address_key(addresses: &[Address]) -> String {
+    addresses
+        .first()
+        .map(|a| a.name.clone().unwrap_or_else(|| a.email.clone()))
+        .unwrap_or_default()
+        .to_lowercase()
+}
+
+/// Shared-DSL filter → RFC 3501 SEARCH keys. Mirrors io-email's
+/// private `convert_filter` so the fallback matches exactly what the
+/// SORT-based path would have matched.
+fn convert_filter(filter: &SearchEmailsFilterQuery) -> Result<SearchKey<'static>> {
+    use SearchEmailsFilterQuery as Q;
+
+    Ok(match filter {
+        Q::And(left, right) => {
+            let keys = vec![convert_filter(left)?, convert_filter(right)?];
+            SearchKey::And(Vec1::try_from(keys).expect("non-empty by construction"))
+        }
+        Q::Or(left, right) => SearchKey::Or(
+            Box::new(convert_filter(left)?),
+            Box::new(convert_filter(right)?),
+        ),
+        Q::Not(inner) => SearchKey::Not(Box::new(convert_filter(inner)?)),
+
+        Q::Date(date) => SearchKey::SentOn(imap_date(*date)?),
+
+        // AfterDate is strict "> D"; SENTSINCE is ">=", so bump by one
+        // day (same as io-email).
+        Q::AfterDate(date) => {
+            let bumped = date.succ_opt().unwrap_or(*date);
+            SearchKey::SentSince(imap_date(bumped)?)
+        }
+
+        Q::From(pattern) => SearchKey::From(astring(pattern)?),
+        Q::To(pattern) => SearchKey::To(astring(pattern)?),
+        Q::Subject(pattern) => SearchKey::Subject(astring(pattern)?),
+        Q::Body(pattern) => SearchKey::Body(astring(pattern)?),
+
+        Q::Flag(flag) => match flag.iana() {
+            Some(IanaFlag::Seen) => SearchKey::Seen,
+            Some(IanaFlag::Answered) => SearchKey::Answered,
+            Some(IanaFlag::Flagged) => SearchKey::Flagged,
+            Some(IanaFlag::Draft) => SearchKey::Draft,
+            Some(IanaFlag::Deleted) => SearchKey::Deleted,
+            _ => SearchKey::Keyword(
+                Atom::try_from(String::from(flag.raw()))
+                    .map_err(|_| anyhow!("invalid IMAP keyword `{}`", flag.raw()))?,
+            ),
+        },
+    })
+}
+
+fn astring(pattern: &str) -> Result<AString<'static>> {
+    AString::try_from(String::from(pattern))
+        .map_err(|_| anyhow!("invalid IMAP search pattern `{pattern}`"))
+}
+
+fn imap_date(date: chrono::NaiveDate) -> Result<ImapNaiveDate> {
+    ImapNaiveDate::try_from(date).map_err(|_| anyhow!("invalid IMAP date `{date}`"))
+}
+
+/// FETCH item-name list: UID + FLAGS + ENVELOPE + RFC822.SIZE, plus
+/// BODYSTRUCTURE when `with_attachment` is set (same set io-email
+/// fetches).
+fn build_item_names(with_attachment: bool) -> MacroOrMessageDataItemNames<'static> {
+    let mut names = vec![
+        MessageDataItemName::Uid,
+        MessageDataItemName::Flags,
+        MessageDataItemName::Envelope,
+        MessageDataItemName::Rfc822Size,
+    ];
+    if with_attachment {
+        names.push(MessageDataItemName::BodyStructure);
+    }
+    MacroOrMessageDataItemNames::MessageDataItemNames(names)
+}
+
+/// Folds one FETCH row into a shared [`Envelope`]. Mirrors io-email's
+/// private `envelope_from`.
+fn envelope_from(seq: u32, items: Vec<MessageDataItem<'static>>) -> Envelope {
+    let mut id = String::new();
+    let mut message_id: Option<String> = None;
+    let mut flags = std::collections::BTreeSet::new();
+    let mut subject = String::new();
+    let mut from = Vec::new();
+    let mut to = Vec::new();
+    let mut date: Option<DateTime<FixedOffset>> = None;
+    let mut size: u64 = 0;
+    let mut has_attachment: Option<bool> = None;
+
+    for item in items {
+        match item {
+            MessageDataItem::Uid(uid) => {
+                id = uid.get().to_string();
+            }
+            MessageDataItem::Flags(fs) => {
+                flags = fs.into_iter().filter_map(flag_from_fetch).collect();
+            }
+            MessageDataItem::Envelope(env) => {
+                if let Some(s) = env.subject.into_option() {
+                    subject = decode_mime_bytes(s.as_ref());
+                }
+                if let Some(d) = env.date.into_option() {
+                    let raw = bytes_to_string(d.as_ref());
+                    date = DateTime::parse_from_rfc2822(raw.trim()).ok();
+                }
+                if let Some(m) = env.message_id.into_option() {
+                    let raw = bytes_to_string(m.as_ref());
+                    message_id = normalize_message_id(&raw);
+                }
+                from = env.from.iter().map(address_from).collect();
+                to = env.to.iter().map(address_from).collect();
+            }
+            MessageDataItem::Rfc822Size(n) => {
+                size = u64::from(n);
+            }
+            MessageDataItem::BodyStructure(structure) => {
+                has_attachment = Some(body_structure_has_attachment(&structure));
+            }
+            _ => {}
+        }
+    }
+
+    if id.is_empty() {
+        id = seq.to_string();
+    }
+
+    Envelope {
+        id,
+        message_id,
+        flags,
+        subject,
+        from,
+        to,
+        date,
+        size,
+        has_attachment,
+    }
+}
+
+fn flag_from_fetch(fetch: FlagFetch<'_>) -> Option<Flag> {
+    let FlagFetch::Flag(flag) = fetch else {
+        return None;
+    };
+    Some(Flag::from_raw(flag.to_string()))
+}
+
+fn address_from(addr: &ImapAddress<'_>) -> Address {
+    let name = addr
+        .name
+        .0
+        .as_ref()
+        .map(|s| decode_mime_bytes(s.as_ref()))
+        .filter(|s| !s.is_empty());
+
+    let mailbox = addr
+        .mailbox
+        .0
+        .as_ref()
+        .map(|s| bytes_to_string(s.as_ref()))
+        .unwrap_or_default();
+
+    let host = addr
+        .host
+        .0
+        .as_ref()
+        .map(|s| bytes_to_string(s.as_ref()))
+        .unwrap_or_default();
+
+    let email = if mailbox.is_empty() {
+        host
+    } else if host.is_empty() {
+        mailbox
+    } else {
+        format!("{mailbox}@{host}")
+    };
+
+    Address { name, email }
+}
+
+fn body_structure_has_attachment(structure: &BodyStructure<'_>) -> bool {
+    match structure {
+        BodyStructure::Single { extension_data, .. } => {
+            let Some(ext) = extension_data.as_ref() else {
+                return false;
+            };
+            let Some(disposition) = ext.tail.as_ref() else {
+                return false;
+            };
+            let Some((kind, _)) = disposition.disposition.as_ref() else {
+                return false;
+            };
+            kind.as_ref().eq_ignore_ascii_case(b"attachment")
+        }
+        BodyStructure::Multi { bodies, .. } => {
+            bodies.as_ref().iter().any(body_structure_has_attachment)
+        }
+    }
+}
+
+fn bytes_to_string(bytes: &[u8]) -> String {
+    from_utf8(bytes)
+        .map(ToString::to_string)
+        .unwrap_or_else(|_| bytes.iter().map(|b| *b as char).collect())
+}
+
+/// Decodes RFC 2047 MIME-encoded words from IMAP ENVELOPE strings;
+/// falls back to [`bytes_to_string`] on malformed input.
+fn decode_mime_bytes(bytes: &[u8]) -> String {
+    let decoder = Decoder::new().too_long_encoded_word_strategy(RecoverStrategy::Decode);
+    decoder
+        .decode(bytes)
+        .unwrap_or_else(|_| bytes_to_string(bytes))
+}


### PR DESCRIPTION
Follow-up to #699 and fix for #698 — this PR carries the two concrete outcomes of that discussion: the documentation improvements we agreed on (general docs for humans and agents alike, no agent-specific file), and a fix for the Gmail search breakage found while testing v2.

### 1. `fix(imap)`: UID SEARCH fallback when the server lacks SORT

The shared `envelope search` always issues `UID SORT`, even with no `order by` clause; Gmail (no RFC 5256 support) rejects it with `BAD Unknown command: UID SORT`, so **every shared search fails against Gmail** while `envelope list` works.

This PR detects the tagged NO/BAD refusal and reruns the same filter as a plain `UID SEARCH` on the same session:

- **without `order by`** — matching UIDs come back newest-first (descending UID ≈ arrival order, a close approximation of the `REVERSE DATE` default) and only the requested page is fetched;
- **with `order by`** — every matching envelope is fetched in chunks of 500 and sorted client-side before pagination (what v1 did; can be slow on huge match sets, documented as such).

Design notes, very open to direction here:

- The FETCH→`Envelope` conversion mirrors io-email's private `envelope_from` so fallback results are byte-identical to the SORT path's. The durable home for all of this is probably io-email's search coroutine itself (try SORT, degrade to SEARCH); I kept it CLI-side so himalaya works against Gmail without waiting on an io-email release, and the module doc marks it as deletable once io-email grows the fallback. Happy to port it down into io-email instead if you'd rather fix it there first.
- Error-driven rather than capability-driven detection (a server advertising SORT but failing it still gets the fallback; transport errors bubble up unchanged).

Verified live against imap.gmail.com on INBOX and `[Gmail]/All Mail`: filter searches, `order by date desc` / `order by subject asc`, pagination (`-p`/`-s`), `--json` output, and clean stderr. `cargo fmt` and `clippy` pass.

### 2. `docs`: README + config.sample.toml

- **Singular command names** — the shared-API examples still used the pre-3a1a981b plural forms (`mailboxes list`, `envelopes search`, `messages send`), which the binary rejects. Fixed throughout, leaving the genuinely-plural protocol groups (`jmap mailboxes`, `smtp messages`) untouched.
- **Search docs** — point to `envelope search --help` as the source of truth for the DSL (per your preference for `--help` over duplicated docs), note that provider-native operators (Gmail `X-GM-RAW`) are unsupported, and describe the new SORT-less fallback behaviour.
- **Draft/send recipe** — `message add -m drafts --flag draft < message.eml` and `message send --save sent`, in the composing section.
- **Reading messages section** — it was already in the TOC but missing from the body; now covers side-effect-free reads (`BODY.PEEK`, no `\Seen`), per-mailbox ids vs the stable `message-id`, and the `--json` envelope shape.
- **config.sample.toml Gmail notes** — labels as top-level mailboxes, the quoted `[Gmail]/` prefix, an `archive = "[Gmail]/All Mail"` alias example, and an app-password pointer next to SASL PLAIN.

Split into three conventional commits (1 fix, 2 docs) so anything you'd rather not take is easy to drop. One correction to my issue comment: the FAQ's `passwd` vs the sample's `password` is not a mismatch — both work via serde alias.

Fixes #698.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

