### PR TITLE
fix(deps): enable mail-parser full_encoding for legacy CJK charsets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,6 +1402,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8a2420e9ce11c2b0583ca97ddff7ab2398c8a613154e9b72e3bafdbf767f1d7"
 dependencies = [
+ "encoding_rs",
  "hashify",
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ io-maildir = { version = "0.1", default-features = false, optional = true }
 io-smtp = { version = "0.1", default-features = false, optional = true }
 log = "0.4"
 mail-builder = "0.4"
-mail-parser = { version = "0.11", features = ["serde"], optional = true }
+mail-parser = { version = "0.11", features = ["full_encoding", "serde"], optional = true }
 mime_guess = { version = "2", optional = true }
 open = "5"
 pimalaya-cli = { version = "0.0.1", default-features = false, features = ["terminal", "table", "prompt", "wizard", "imap", "smtp", "jmap", "spinner"] }


### PR DESCRIPTION
## What

Add the `full_encoding` feature to the `mail-parser` dependency:

## Why

Without `full_encoding`, `mail-parser` compiles only the UTF-8 / ASCII decoders. A message whose body or RFC 2047 encoded-word headers use a legacy charset (ISO-2022-JP, Shift-JIS, EUC-JP, GBK, Big5, windows-*) is passed through undecoded and renders as mojibake in `message read`. These charsets are still widely used by Japanese bank / utility / corporate senders.

Found while testing the new Gmail backend (ref #643) against a real account.

### Before — `message read` on a real `Content-Type: text/plain; charset=ISO-2022-JP` body

```
$B!Z$/$i$7(BTEPCO web$B![%]%$%s%H;D9b99?7$N$*CN$i$;...
```

(raw ISO-2022-JP escape sequences leaking through; the encoded-word `Subject` is mojibake the same way)

### After

```
いつも「くらしTEPCO web」をご利用いただき、誠にありがとうございます。
ポイント残高が更新されました。
```

## Scope

Listing (`envelope list`, `gmail messages list`) was unaffected — it uses header values already decoded by the Gmail API. Only the `format=RAW` → `mail-parser` path in `message read` was broken, so the same fix benefits the IMAP / JMAP / Maildir readers, which parse RAW the same way.

The change pulls in `encoding_rs` as a transitive dependency of `mail-parser`.
