### PR TITLE
fix crossterm-style colors in sample config

### DIFF
--- a/config.sample.toml
+++ b/config.sample.toml
@@ -50,7 +50,7 @@
 # --------------------------------------------------------------------------------
 
 # Per-column foreground colors for the `envelopes list` table. Each value is
-# a crossterm-style color: a named variant (`"red"`, `"dark-magenta"`,
+# a crossterm-style color: a named variant (`"red"`, `"dark_magenta"`,
 # `"reset"`, …), or a `{ Rgb = { r, g, b } }` / `{ AnsiValue = N }` table.
 # Applied to both shared `envelopes list` and the protocol-specific
 # `imap`/`jmap`/`maildir` envelope listings so a single key affects every
@@ -62,7 +62,7 @@
 #envelope.list.table.subject-color = "green"
 #envelope.list.table.from-color = "blue"
 #envelope.list.table.to-color = "blue"
-#envelope.list.table.date-color = "dark-yellow"
+#envelope.list.table.date-color = "dark_yellow"
 #envelope.list.table.size-color = "reset"
 
 # Single-character glyphs used inside the FLAGS / ATT columns of the


### PR DESCRIPTION
> [!note]
> i thought it was not useful to open an issue before-hand for such a small and simple fix :)

on 7fbb314, the current `master`, following the sample config
```toml
envelope.list.table.date-color = "dark-yellow"

# some valid account ...
```

i get a TOML parsing error
```console
cargo run -- --config pr-config.toml -a ... env ls -m inbox
```
```
Error: Parse TOML config error

Caused by:
 - TOML parse error at line 1, column 34
  |
1 | envelope.list.table.date-color = "dark-yellow"
  |                                  ^^^^^^^^^^^^^
invalid value: string "dark-yellow", expected `reset`, `black`, `blue`, `dark_blue`, `cyan`, `dark_cyan`, `green`, `dark_green`, `grey`, `dark_grey`, `magenta`, `dark_magenta`, `red`, `dark_red`, `white`, `yellow`, `dark_yellow`, `ansi_(value)`, or `rgb_(r,g,b)` or `#rgbhex`
```

this PR fixes the sample config.