### PR TITLE
fix(send): inject Date header when missing on send path

### DIFF
--- a/cairn/changes/send-missing-date-header/delta.md
+++ b/cairn/changes/send-missing-date-header/delta.md
@@ -1,0 +1,12 @@
+# Delta
+
+## ADDED Requirements
+
+The shared send path SHALL ensure the message carries an origination
+date before handing it to any backend: `EmailClient::send_message`
+prepends `Date: <now>` (RFC 5322 date-time with the local UTC offset)
+when the message has no `Date:` header, and leaves a message that
+already carries one byte-identical. This covers every shared command
+that sends (`message send`, `compose`, `reply`, `forward`) across
+every send-capable backend (SMTP, JMAP, Gmail, Graph). The `smtp send`
+plumbing command stays byte-exact and is exempt.

--- a/cairn/changes/send-missing-date-header/proposal.md
+++ b/cairn/changes/send-missing-date-header/proposal.md
@@ -1,0 +1,45 @@
+---
+cairn: change
+id: send-missing-date-header
+status: active
+created: 2026-08-15
+---
+
+# Send missing Date header
+
+## Why
+
+A message sent through the shared send path without a `Date:` header
+is delivered as-is: nothing between the user's bytes and the wire adds
+one. Receiving IMAP servers then display the message at the Unix epoch
+(1970-01-01), which breaks sorting, threading and search for the
+recipient.
+
+Reproduced on v1.2.0 with `himalaya template send < message.eml`
+where `message.eml` carries no `Date:`; the delivered copy arrives
+stamped 1970-01-01. On master the same gap exists: `message send`
+pipes raw bytes through `handler::route` into `EmailClient::send_message`
+untouched, the built-in composers (`compose` / `reply` / `forward`)
+never set a `Date:` either, and none of the backend adapters (SMTP,
+JMAP, Gmail, Graph) inject one.
+
+RFC 5322 §3.6 lists the origination date field as one of the two
+mandatory header fields (with `From:`).
+
+## What
+
+`EmailClient::send_message` — the single choke point every shared send
+path funnels through — prepends `Date: <now>` (RFC 5322 date-time with
+local UTC offset, via `chrono::Local`) when the message carries no
+`Date:` header. An existing `Date:` is never modified: a message that
+already has one passes through byte-identical. The injected line
+follows the message's own line-ending convention (CRLF or LF).
+
+The `smtp send` plumbing command is deliberately out of scope: it is
+an explicit-envelope raw transaction tool and stays byte-exact.
+
+## Scope / non-goals
+
+No `Message-ID:` injection. Also recommended by RFC 5322 §3.6, but a
+separate decision with its own trade-offs (some MTAs add one
+themselves); kept out to keep this change minimal.

--- a/cairn/changes/send-missing-date-header/tasks.md
+++ b/cairn/changes/send-missing-date-header/tasks.md
@@ -1,0 +1,9 @@
+# Tasks
+
+- [x] Locate the send choke point (`EmailClient::send_message`)
+- [x] Prepend `Date:` when missing, never touch an existing one
+- [x] Unit tests: injection on missing Date, byte-identical
+  preservation of an existing Date, LF/CRLF line-ending match
+- [x] `cargo test -p himalaya` passes
+- [ ] Maintainer review and landing (fold delta into
+  `cairn/spec/commands.md`, write the log entry, set `status: landed`)

--- a/src/shared/client.rs
+++ b/src/shared/client.rs
@@ -16,6 +16,8 @@
 use std::mem;
 
 use anyhow::{Result, anyhow, bail};
+#[cfg(any(backend, feature = "smtp"))]
+use mail_parser::MessageParser;
 
 #[cfg(feature = "gmail")]
 use crate::gmail::client::GmailClient;
@@ -413,8 +415,13 @@ impl EmailClient {
     }
 
     /// Sends `raw`: through the storage backend when it can send itself
-    /// (JMAP, Gmail, Graph), otherwise through the SMTP transport.
+    /// (JMAP, Gmail, Graph), otherwise through the SMTP transport. A
+    /// missing `Date:` header is filled in first (see
+    /// [`with_origination_date`]).
     pub fn send_message(&mut self, raw: Vec<u8>) -> Result<()> {
+        #[cfg(any(backend, feature = "smtp"))]
+        let raw = with_origination_date(raw);
+
         match &mut self.storage {
             #[cfg(feature = "jmap")]
             Some(BackendClient::Jmap(client)) => return client.send_message(raw),
@@ -567,4 +574,89 @@ fn select_storage(
     }
 
     Ok(None)
+}
+
+/// Prepends a `Date:` header carrying the current local date and time
+/// when `raw` has none. RFC 5322 §3.6 requires every message to carry
+/// an origination date, but a raw message piped into `message send`
+/// (or assembled by the built-in composers, which never set one) may
+/// lack it; receiving servers then file the message at the Unix
+/// epoch. An existing `Date:` header is never modified.
+#[cfg(any(backend, feature = "smtp"))]
+fn with_origination_date(mut raw: Vec<u8>) -> Vec<u8> {
+    let has_date = MessageParser::default()
+        .parse_headers(&raw)
+        .is_some_and(|parsed| parsed.header("Date").is_some());
+
+    if has_date {
+        return raw;
+    }
+
+    // Match the message's own line-ending convention so an LF-only
+    // message does not gain a lone CR.
+    let eol = match raw.iter().position(|&b| b == b'\n') {
+        Some(i) if i > 0 && raw[i - 1] == b'\r' => "\r\n",
+        _ => "\n",
+    };
+
+    let date = chrono::Local::now().to_rfc2822();
+    let mut header = format!("Date: {date}{eol}").into_bytes();
+    header.append(&mut raw);
+    header
+}
+
+#[cfg(all(test, any(backend, feature = "smtp")))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn send_injects_date_header_when_missing() {
+        let raw =
+            b"From: alice@example.com\r\nTo: bob@example.com\r\nSubject: Hi\r\n\r\nbody\r\n"
+                .to_vec();
+
+        let out = with_origination_date(raw.clone());
+
+        assert!(out.starts_with(b"Date: "));
+        // CRLF message: the injected line is CRLF-terminated.
+        let eol = out.iter().position(|&b| b == b'\n').unwrap();
+        assert_eq!(out[eol - 1], b'\r');
+        // The injected value is a valid RFC 5322 date-time…
+        let parsed = MessageParser::default()
+            .parse_headers(&out)
+            .expect("message with injected Date should parse");
+        assert!(parsed.date().is_some());
+        // …and the original message survives byte-for-byte after it.
+        assert!(out.ends_with(raw.as_slice()));
+    }
+
+    #[test]
+    fn send_preserves_existing_date_header_byte_identically() {
+        let raw = b"From: alice@example.com\r\n\
+Date: Thu, 01 Jan 1970 00:00:00 +0000\r\n\
+To: bob@example.com\r\n\
+\r\n\
+body\r\n"
+            .to_vec();
+
+        let out = with_origination_date(raw.clone());
+
+        assert_eq!(out, raw);
+    }
+
+    #[test]
+    fn send_injected_date_matches_lf_line_endings() {
+        let raw = b"From: alice@example.com\nTo: bob@example.com\n\nbody\n".to_vec();
+
+        let out = with_origination_date(raw.clone());
+
+        // An LF-only message gains an LF-terminated Date line, no CR.
+        let eol = out.iter().position(|&b| b == b'\n').unwrap();
+        assert_ne!(out[eol - 1], b'\r');
+        let parsed = MessageParser::default()
+            .parse_headers(&out)
+            .expect("message with injected Date should parse");
+        assert!(parsed.date().is_some());
+        assert!(out.ends_with(raw.as_slice()));
+    }
 }


### PR DESCRIPTION
## Symptom

Sending a raw RFC 5322 message that has no `Date:` header delivers it without one. The receiving IMAP server then files it at the Unix epoch — the message shows up dated **1970-01-01**.

Reproduced twice on 2026-08-15 with himalaya v1.2.0 (linux musl aarch64):

```console
$ printf 'From: me@example.com\r\nTo: you@example.net\r\nSubject: date test\r\n\r\nbody\r\n' > /tmp/no-date.eml
$ himalaya template send < /tmp/no-date.eml
# delivered, but arrives in the recipient's mailbox stamped 1970-01-01
```

On master (v2.0.0) the equivalent entry point is `himalaya message send < /tmp/no-date.eml`, which has the same gap.

## Root cause

The shared send path never inspects the message it transmits:

- `message send` resolves raw bytes via `MessageArg` and passes them through `handler::route` → `handler::apply` → `EmailClient::send_message` untouched.
- The built-in composers (`compose` / `reply` / `forward`, `shared/message/builder.rs`) assemble MIME with `mail_builder` and never set a `Date:` either, so the gap affects every send path, not just raw input.
- None of the backend adapters (`smtp/backend.rs`, `jmap/backend.rs`, `gmail/backend.rs`, `msgraph/backend.rs`) inject one; each transmits the bytes it is given.

RFC 5322 §3.6 lists the origination date as one of the only two mandatory header fields (with `From:`).

## Fix

`EmailClient::send_message` (`src/shared/client.rs`) is the single choke point every shared send path funnels through. It now prepends `Date: <now>` — RFC 5322 date-time with the local UTC offset via `chrono::Local` (`chrono` with `clock` is already a dependency) — when the message carries no `Date:` header. A message that already has one passes through **byte-identical**; the header is never overwritten. The injected line matches the message's own line-ending convention (CRLF or LF).

The `smtp send` plumbing command (explicit-envelope raw transaction) is intentionally left byte-exact.

## Test

Three unit tests next to the fix in `src/shared/client.rs`:

- `send_injects_date_header_when_missing` — no `Date:` in → valid, parseable `Date:` present after the transform; original bytes preserved after the prepended line
- `send_preserves_existing_date_header_byte_identically` — existing `Date:` → output equals input exactly
- `send_injected_date_matches_lf_line_endings` — an LF-only message gains an LF-terminated `Date:` line

TEST_RESULT_PLACEHOLDER

## Notes

- I searched open+closed upstream issues for "Date header", "missing date", "1970" and "epoch" before filing — nothing matched (#726 is about `From:`, unrelated), so no issue is duplicated here.
- Per this repo's Cairn convention the PR includes `cairn/changes/send-missing-date-header/` (`status: active`); folding the delta into `cairn/spec/commands.md` and writing the log entry are left for landing, as noted in its `tasks.md`.
- `Message-ID:` injection (also recommended by RFC 5322 §3.6) is intentionally out of scope to keep the change minimal.
