### PR TITLE
Add ManageSieve support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,11 +24,12 @@ The clap, printer, prompt and spinner primitives come from [pimalaya/cli](https:
 
 ## Feature matrix
 
-Himalaya is a binary, not a layered library, so it has no coroutine/client split. Its cargo features gate the backends (`imap`, `smtp`, `jmap`, `gmail`, `msgraph`, `maildir`, `m2dir`), the setup `wizard`, and the TLS provider (`rustls-ring` default, `rustls-aws`, `native-tls`), all on by default. Build a reduced set to check the feature gates still hold when touching them:
+Himalaya is a binary, not a layered library, so it has no coroutine/client split. Its cargo features gate the backends (`imap`, `smtp`, `jmap`, `gmail`, `msgraph`, `maildir`, `m2dir`), the ManageSieve service protocol (`sieve`), the setup `wizard`, and the TLS provider (`rustls-ring` default, `rustls-aws`, `native-tls`), all on by default. Build a reduced set to check the feature gates still hold when touching them:
 
 ```sh
 cargo build --no-default-features --features imap,smtp,rustls-ring
 cargo build --no-default-features --features jmap,rustls-ring
+cargo test --no-default-features --features sieve,rustls-ring
 ```
 
 ## Dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,17 +7,18 @@ rust-version = "1.89"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 categories = ["command-line-utilities", "email"]
-keywords = ["cli", "email", "imap", "maildir", "smtp"]
+keywords = ["cli", "email", "imap", "maildir", "sieve", "smtp"]
 homepage = "https://pimalaya.org"
 repository = "https://github.com/pimalaya/himalaya"
 
 [features]
-default = ["rustls-ring", "imap", "smtp", "jmap", "gmail", "msgraph", "maildir"]
+default = ["rustls-ring", "imap", "smtp", "sieve", "jmap", "gmail", "msgraph", "maildir"]
 imap = ["dep:io-imap", "dep:mail-parser", "dep:rfc2047-decoder", "io-imap/client"]
 jmap = ["dep:base64", "dep:io-jmap", "dep:mail-parser", "io-jmap/client", "io-jmap/schemars"]
 gmail = ["dep:io-gmail", "dep:mail-parser", "io-gmail/client", "io-gmail/schemars"]
 msgraph = ["dep:io-msgraph", "dep:mail-parser", "io-msgraph/client", "io-msgraph/schemars"]
 smtp = ["dep:io-smtp", "dep:mail-parser"]
+sieve = ["dep:base64"]
 maildir = ["dep:convert_case", "dep:io-maildir", "dep:mail-parser", "io-maildir/client", "io-maildir/parser"]
 m2dir = ["dep:convert_case", "dep:io-m2dir", "dep:mail-parser", "io-m2dir/client"]
 pimdir = ["dep:io-pimdir", "dep:io-replica", "dep:mail-parser"]

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@
 
 - **Shared API** for `mailboxes`, `envelopes`, `flags`, `messages` and `attachments`
 - **Protocol-specific APIs** exposing each backend's full surface
-- **IMAP**, **SMTP**, **JMAP**, **Gmail** (REST API), **Microsoft Graph** (Outlook / Microsoft 365) support
+- **IMAP**, **SMTP**, **ManageSieve**, **JMAP**, **Gmail** (REST API), **Microsoft Graph** (Outlook / Microsoft 365) support
 - **Maildir** <sup>[specs](https://cr.yp.to/proto/maildir.html)</sup>, **m2dir** <sup>[specs](https://man.sr.ht/~bitfehler/m2dir/)</sup>, **pimdir** <sup>[specs](https://github.com/pimalaya/pimdir)</sup> support
-- **Simple auth** support for IMAP/SMTP: anonymous, login, plain, oauthbearer, xoauth2, scram-sha-256
+- **Simple auth** support for IMAP/SMTP (anonymous, login, plain, oauthbearer, xoauth2, scram-sha-256) and ManageSieve (login, plain)
 - **HTTP auth** support for JMAP: basic, bearer
 - **TLS** support:
   - [Rustls](https://crates.io/crates/rustls) with ring crypto
@@ -343,7 +343,16 @@ himalaya jmap mailbox query --role drafts
 himalaya gmail messages list -q "from:alice is:unread"
 himalaya msgraph mail-folder list
 himalaya smtp send -f me@example.com -t you@example.com < message.eml
+himalaya sieve list
+himalaya sieve check --script-file filters.sieve
+himalaya sieve activate main
 ```
+
+ManageSieve uses the optional `sieve` account block. A bare server address
+defaults to implicit TLS on port 4190; use `sieve://...` together with
+`sieve.starttls = true` for STARTTLS. `sieve capability`, `list`, `get`,
+`put`, `check`, `activate`, `deactivate`, `delete`, and `raw` are available.
+`put` and `check` accept a script file, inline text after `--`, or stdin.
 
 ### Composing messages
 

--- a/cairn/changes/managesieve-support/delta.md
+++ b/cairn/changes/managesieve-support/delta.md
@@ -1,0 +1,40 @@
+---
+cairn: change-delta
+id: managesieve-support
+status: landed
+---
+
+## ADDED Requirements
+
+### Requirement: ManageSieve account transport
+
+An account MAY declare a `sieve` block using `sieve://`, `sieves://`, or
+`unix://` server URLs. The transport SHALL support implicit TLS, STARTTLS,
+and the account's configured SASL credentials where the mechanism is
+supported by ManageSieve.
+
+### Requirement: ManageSieve protocol commands
+
+When built with the `sieve` feature, Himalaya SHALL expose protocol-specific
+commands for `capability`, `list`, `get`, `put`, `check`, `activate`,
+`deactivate`, `delete`, and `raw`. Commands SHALL use the resolved account
+and SHALL keep protocol data output separate from confirmation messages.
+
+### Requirement: ManageSieve wire safety
+
+The client SHALL frame CRLF-terminated commands and RFC 5804 quoted/literal
+strings, consume complete server responses, reject unsafe cleartext password
+authentication, and preserve server failure status as a user-visible error.
+
+### Requirement: Local ManageSieve verification
+
+Protocol framing and command sequencing SHALL be covered by unit tests and a
+local fake ManageSieve server. Live provider tests SHALL remain separate from
+the default test suite and SHALL use only explicitly safe test scripts.
+
+## MODIFIED Requirements
+
+### Requirement: Protocol-specific APIs
+
+The protocol-specific API list now includes `sieve`; it is an optional
+service protocol and does not become a shared mail-storage backend.

--- a/cairn/changes/managesieve-support/proposal.md
+++ b/cairn/changes/managesieve-support/proposal.md
@@ -1,0 +1,18 @@
+---
+cairn: change
+id: managesieve-support
+status: landed
+created: 2026-08-24
+---
+
+# ManageSieve support
+
+Himalaya accounts that use Dovecot or another RFC 5804 ManageSieve server
+should be able to inspect and maintain their server-side Sieve scripts
+through the same account-scoped CLI style as the existing protocol modules.
+
+This change adds an optional `sieve` account transport and a protocol module
+covering capability discovery, script listing and retrieval, upload and
+validation, activation/deactivation, deletion, and a diagnostic raw command.
+The wire framing stays isolated from the CLI so literal strings, CRLFs, and
+server status responses can be tested with a local fake server first.

--- a/cairn/changes/managesieve-support/tasks.md
+++ b/cairn/changes/managesieve-support/tasks.md
@@ -1,0 +1,13 @@
+---
+cairn: change-tasks
+id: managesieve-support
+status: landed
+---
+
+- [x] Add the optional Sieve account configuration and feature gate.
+- [x] Implement ManageSieve transport, authentication, literals, and status handling.
+- [x] Add Himalaya-style protocol commands and JSON schemas.
+- [x] Add configuration and command documentation.
+- [x] Add local parser and fake-server tests.
+- [x] Run formatting, feature-matrix builds, and the full test suite.
+- [x] Fold the change into current Cairn specs and write a landing log.

--- a/cairn/log/2026-08-24-managesieve-support.md
+++ b/cairn/log/2026-08-24-managesieve-support.md
@@ -1,0 +1,58 @@
+---
+cairn: log
+change: managesieve-support
+landed: 2026-08-24
+---
+
+# ManageSieve support
+
+The optional `sieve` feature adds an account-scoped ManageSieve transport and
+protocol command family. It supports `sieve://`, `sieves://`, and Unix socket
+servers, implicit TLS, STARTTLS, LOGIN and PLAIN authentication, capabilities,
+script listing and retrieval, upload and validation, activation/deactivation,
+deletion, and a diagnostic raw command.
+
+The wire implementation keeps CRLF framing, quoted strings, literals, and
+server status handling inside the Sieve client. The CLI follows the existing
+protocol-module style and exposes structured output for capabilities, scripts,
+and script retrieval.
+
+Verification completed locally:
+
+- `cargo fmt --all`
+- `cargo test --all-targets` — 116 tests passed
+- `cargo test --no-default-features --features sieve,rustls-ring` — 71 tests passed
+- `cargo check --no-default-features --features sieve,rustls-ring`
+- `cargo build --no-default-features --features imap,smtp,rustls-ring`
+- `cargo build --no-default-features --features jmap,rustls-ring`
+- `cargo deny check`
+- Sieve-focused Clippy with the pre-existing wizard lint allowed
+- release-feature build and CLI help smoke tests
+
+The fake-server test covers the command sequence and literal handling without
+touching a real mailbox.
+
+Live read-only smoke test completed against the user's global `franz` account
+(`franz@bett.ag`) on `mail2.anycast.io:4190`: implicit TLS was rejected by the
+server, while `sieve://` plus STARTTLS succeeded. Dovecot Pigeonhole reported
+Sieve 1.0 and SASL PLAIN; authenticated `LISTSCRIPTS` returned an empty list,
+and `account check --backend sieve` returned `OK`. The server-side
+`.dovecot.sieve` was a regular file outside the personal ManageSieve store.
+With explicit authorization, Himalaya then uploaded the supplied rules as
+`main` and activated it. `LISTSCRIPTS` showed `main` active and `dovecot.orig`
+inactive; `GETSCRIPT` verified that both contained the original rules. No
+script was deleted manually. A cleartext-auth guard bug found during the
+first test was fixed so PLAIN/LOGIN are allowed after STARTTLS but remain
+blocked on unencrypted connections.
+
+The final local hardening also rejects overlong response lines and caps
+server-declared literals before allocation; parser tests cover literal token
+boundaries and the allocation guard.
+
+The same authorized migration was then verified for `mail@anycast.io` on
+`mail1.anycast.io`. The existing regular `.dovecot.sieve` contained the
+invoice forwarding rule. Himalaya uploaded it as `main` and activated it;
+Dovecot created the managed `sieve/main.sieve` symlink and preserved the old
+file as inactive `dovecot.orig`. `sieve list`, `doveadm sieve list`, and
+`doveadm sieve get` agreed on the active script and its contents. No manual
+symlink or direct filesystem edit was used.

--- a/cairn/spec/commands.md
+++ b/cairn/spec/commands.md
@@ -6,7 +6,7 @@ status: current
 
 # Commands
 
-The command tree splits into three groups. The shared API (mailbox, envelope, flag, message, attachment) is the cross-protocol least-common-denominator surface, behaving the same whatever backend serves the active account. The protocol-specific APIs (imap, jmap, gmail, msgraph, maildir, m2dir, smtp) each expose the full surface of one backend, including operations the shared API cannot model. The meta commands (account, completion, manual) cover account configuration, shell completions and man pages.
+The command tree splits into three groups. The shared API (mailbox, envelope, flag, message, attachment) is the cross-protocol least-common-denominator surface, behaving the same whatever backend serves the active account. The protocol-specific APIs (imap, jmap, gmail, msgraph, maildir, m2dir, smtp, sieve) each expose the full surface of one backend, including operations the shared API cannot model. The meta commands (account, completion, manual) cover account configuration, shell completions and man pages.
 
 ### Requirement: Shared commands over a selected backend
 The shared commands SHALL run over an `EmailClient` that owns one backend-client variant per compiled-in backend. It selects the first configured storage backend the global `--backend` flag allows, preferring local backends over network ones, plus an optional SMTP transport for storage backends that cannot send (IMAP, Maildir, m2dir). Each shared method matches the active backend and calls its per-protocol adapter.
@@ -14,8 +14,16 @@ The shared commands SHALL run over an `EmailClient` that owns one backend-client
 ### Requirement: Protocol commands ignore backend selection
 Each protocol command SHALL build its own `<Proto>Client` via a `build_<proto>_client` helper and run against that backend directly, ignoring `--backend`. The imap command mirrors IMAP's flat command list; gmail and msgraph track their REST resource domains; the filesystem backends expose only operations that map to their on-disk layout, leaving MIME rendering to the shared commands.
 
+### Requirement: ManageSieve commands
+
+When built with the `sieve` feature, the protocol-specific API SHALL expose
+`sieve capability`, `list`, `get`, `put`, `check`, `activate`, `deactivate`,
+`delete`, and `raw`. Data commands SHALL use dedicated serializable output
+types; mutation commands SHALL use confirmation messages. `put` and `check`
+SHALL accept script bytes from a file, inline arguments, or stdin.
+
 ### Requirement: Raw passthrough is byte-verbatim
-The `imap raw` and `smtp raw` commands SHALL forward the command bytes to the server verbatim, resolving the argument through the shared `RawCommandArg` (positional or stdin). It decodes literal `\r` / `\n` escapes into real CRLF so a shell-typed command survives intact. `imap raw` sends a batch of caller-tagged commands: it appends a trailing CRLF when missing and delegates tagging, framing and out-of-order completion tracking to io-imap. `smtp raw` stays a single command line: it strips the trailing CRLF (io-smtp appends its own) and rejects a multi-line batch, since the SMTP exchange reads exactly one reply.
+The `imap raw` and `smtp raw` commands SHALL forward the command bytes to the server verbatim, resolving the argument through the shared `RawCommandArg` (positional or stdin). It decodes literal `\r` / `\n` escapes into real CRLF so a shell-typed command survives intact. `imap raw` sends a batch of caller-tagged commands: it appends a trailing CRLF when missing and delegates tagging, framing and out-of-order completion tracking to io-imap. `smtp raw` stays a single command line: it strips the trailing CRLF (io-smtp appends its own) and rejects a multi-line batch, since the SMTP exchange reads exactly one reply. `sieve raw` sends one command line and reads the complete ManageSieve response; literal-bearing Sieve commands use their typed commands so the response reader remains synchronized.
 
 ### Requirement: Account threaded as a sibling argument
 The active account context SHALL be threaded as a sibling argument through every `execute` chain, never reached through the client. Subcommands receive `account` and `client` side by side.

--- a/cairn/spec/config.md
+++ b/cairn/spec/config.md
@@ -9,7 +9,12 @@ status: current
 Himalaya is configured through TOML: a top-level block plus named account blocks, one table per account under `[accounts.<name>]`, each carrying optional per-backend sub-blocks. The config schema is a set of pure DTOs (`*Config` types) mirroring the nested TOML shape; the selected account is flattened into a runtime `Account` view that commands consume. Config files stay user-owned: Himalaya never writes them.
 
 ### Requirement: Multi-account schema
-The config SHALL be multi-account: a top-level block holding shared defaults, plus `[accounts.<name>]` blocks. Each account carries at most one storage backend sub-block (`imap`, `jmap`, `gmail`, `msgraph`, `maildir`, `m2dir`) and an optional `smtp` sub-block for the backends that cannot send.
+The config SHALL be multi-account: a top-level block holding shared defaults, plus `[accounts.<name>]` blocks. Each account carries at most one storage backend sub-block (`imap`, `jmap`, `gmail`, `msgraph`, `maildir`, `m2dir`) and optional service sub-blocks for `smtp` and `sieve`.
+
+The `sieve` block SHALL accept `sieve://`, `sieves://`, and `unix://`
+servers, default bare authorities to implicit TLS on port 4190, and expose
+the shared TLS vocabulary plus optional SASL LOGIN or PLAIN credentials.
+STARTTLS SHALL only be enabled explicitly on a `sieve://` endpoint.
 
 ### Requirement: Config loading and merge
 The config SHALL load from the first existing canonical path (`$XDG_CONFIG_HOME/himalaya/config.toml`, `$HOME/.config/himalaya/config.toml`, `$HOME/.himalayarc`), overridable with `-c/--config`. Multiple `-c` paths MAY be passed, colon-free as repeated flags: the first is the base and the rest are deep-merged on top.

--- a/cairn/spec/testing/README.md
+++ b/cairn/spec/testing/README.md
@@ -64,3 +64,23 @@ io-imap client-side sort fallback ordered the `date` key by the raw
 Everything else on iCloud passed.
 
 Not yet tested: Proton Bridge; SMTP on iCloud (that account is IMAP-only).
+
+ManageSieve has local coverage in the default test suite: a fake server
+exercises greeting capability lines, quoted script names, GETSCRIPT literals,
+HAVESPACE/PUTSCRIPT/CHECKSCRIPT literals, activation, deletion, and logout.
+The 2026-08-24 Dovecot Pigeonhole smoke test against `franz@bett.ag` passed
+STARTTLS, PLAIN authentication, `CAPABILITY`, `LISTSCRIPTS`, and
+`account check --backend sieve`. The initial list was empty because the
+existing `.dovecot.sieve` was a regular file outside the personal store. In
+an explicitly authorized migration test, Himalaya uploaded the same rules as
+`main` and activated it; ManageSieve then listed `main` as active and
+`dovecot.orig` as the preserved inactive copy. `GETSCRIPT` verified both
+contents. No script was deleted.
+
+The same migration path was verified on 2026-08-24 for `mail@anycast.io` on
+`mail1.anycast.io`. Its pre-existing regular `.dovecot.sieve` contained the
+invoice forwarding rule. Himalaya uploaded it as `main` and activated it;
+Dovecot converted `.dovecot.sieve` into its managed `sieve/main.sieve`
+symlink and preserved the previous file as inactive `dovecot.orig`. Himalaya
+and `doveadm` returned the same script contents. No manual symlink or direct
+filesystem edit was used.

--- a/config.sample.toml
+++ b/config.sample.toml
@@ -477,3 +477,32 @@ smtp.sasl.plain.password.raw = "***"
 # SASL SCRAM-SHA-256
 #smtp.sasl.scram-sha-256.username = "user@example.com"
 #smtp.sasl.scram-sha-256.password.raw = "***"
+
+# --------------------------------------------------------------------------------
+# ManageSieve config (RFC 5804)
+# --------------------------------------------------------------------------------
+
+# ManageSieve server. A bare authority defaults to `sieves://` on port 4190;
+# use `sieve://host:4190` for cleartext plus STARTTLS or `unix:///path` for a
+# local pre-authenticated proxy.
+#sieve.server = "sieves://sieve.example.com:4190"
+#sieve.server = "sieve://sieve.example.com:4190"
+#sieve.server = "unix:///run/sieve.sock"
+
+# TLS provider and custom certificate use the same settings as IMAP/SMTP.
+#sieve.tls.provider = "rustls"
+#sieve.tls.provider = "native-tls"
+#sieve.tls.cert = "/path/to/custom/cert.pem"
+
+# Enable STARTTLS only for a `sieve://` endpoint.
+#sieve.starttls = true
+
+# ManageSieve has no standard ALPN identifier; an empty list is the default.
+#sieve.alpn = []
+
+# LOGIN and PLAIN are supported. Credentials must not be sent over an
+# unencrypted `sieve://` connection.
+#sieve.sasl.plain.username = "user@example.com"
+#sieve.sasl.plain.password.command = "pass show sieve"
+#sieve.sasl.login.username = "user@example.com"
+#sieve.sasl.login.password.command = "pass show sieve"

--- a/src/account/check.rs
+++ b/src/account/check.rs
@@ -116,6 +116,15 @@ impl AccountCheckCommand {
                 .push(BackendCheck::from("smtp", connect_smtp(smtp_config)));
         }
 
+        #[cfg(feature = "sieve")]
+        if backend.allows_sieve()
+            && let Some(sieve_config) = &account_config.sieve
+        {
+            report
+                .backends
+                .push(BackendCheck::from("sieve", connect_sieve(sieve_config)));
+        }
+
         if report.backends.is_empty() {
             bail!("No backend matching `{backend}` is configured for this account");
         }
@@ -162,6 +171,11 @@ pub fn test_account(account_config: &AccountConfig) -> Result<()> {
     #[cfg(feature = "smtp")]
     if let Some(smtp_config) = &account_config.smtp {
         connect_smtp(smtp_config)?;
+    }
+
+    #[cfg(feature = "sieve")]
+    if let Some(sieve_config) = &account_config.sieve {
+        connect_sieve(sieve_config)?;
     }
 
     Ok(())
@@ -334,6 +348,12 @@ pub(crate) fn connect_smtp(smtp_config: &crate::config::SmtpConfig) -> Result<()
     };
     let _client = SmtpClientStd::connect(&server, &tls, domain, sasl, opts)?;
 
+    Ok(())
+}
+
+#[cfg(feature = "sieve")]
+pub(crate) fn connect_sieve(sieve_config: &crate::config::SieveConfig) -> Result<()> {
+    let _client = crate::sieve::client::SieveClient::new(sieve_config.clone())?;
     Ok(())
 }
 

--- a/src/account/list.rs
+++ b/src/account/list.rs
@@ -113,6 +113,9 @@ impl AccountRow {
         if account.smtp.is_some() {
             backends.push("smtp");
         }
+        if account.sieve.is_some() {
+            backends.push("sieve");
+        }
 
         Self {
             name: name.to_owned(),

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -10,7 +10,7 @@ use clap::ValueEnum;
 /// (config missing, or the operation has no arm for that backend).
 ///
 /// The protocol-specific subcommands (`imap`, `jmap`, `maildir`,
-/// `m2dir`, `smtp`) ignore this arg entirely.
+/// `m2dir`, `smtp`, `sieve`) ignore this arg entirely.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
 pub enum Backend {
     #[default]
@@ -23,6 +23,7 @@ pub enum Backend {
     M2dir,
     Pimdir,
     Smtp,
+    Sieve,
 }
 
 #[allow(unused)]
@@ -67,6 +68,11 @@ impl Backend {
     pub fn allows_smtp(self) -> bool {
         matches!(self, Self::Auto | Self::Smtp)
     }
+
+    /// Whether the ManageSieve account-check arm is allowed to run.
+    pub fn allows_sieve(self) -> bool {
+        matches!(self, Self::Auto | Self::Sieve)
+    }
 }
 
 impl fmt::Display for Backend {
@@ -81,6 +87,7 @@ impl fmt::Display for Backend {
             Self::M2dir => write!(f, "m2dir"),
             Self::Pimdir => write!(f, "pimdir"),
             Self::Smtp => write!(f, "smtp"),
+            Self::Sieve => write!(f, "sieve"),
         }
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -38,6 +38,8 @@ use crate::shared::{
 // (`compose`/`send`), so they exist for any backend, not just storage.
 #[cfg(any(backend, feature = "smtp"))]
 use crate::shared::{client::EmailClient, message::cli::MessageCommand};
+#[cfg(feature = "sieve")]
+use crate::sieve::{cli::SieveCommand, client::build_sieve_client};
 #[cfg(feature = "smtp")]
 use crate::smtp::{cli::SmtpCommand, client::build_smtp_client};
 use crate::{
@@ -135,6 +137,9 @@ pub enum Command {
     #[cfg(feature = "smtp")]
     #[command(subcommand)]
     Smtp(SmtpCommand),
+    #[cfg(feature = "sieve")]
+    #[command(subcommand)]
+    Sieve(SieveCommand),
 
     // --- Meta
     //
@@ -355,6 +360,13 @@ impl Command {
                     resolve_account(printer, config_paths, account_name)?;
                 let (_account, mut client) = build_smtp_client(config, name, account_config)?;
                 cmd.execute(printer, &mut client)
+            }
+            #[cfg(feature = "sieve")]
+            Self::Sieve(cmd) => {
+                let (config, name, account_config) =
+                    resolve_account(printer, config_paths, account_name)?;
+                let (mut account, mut client) = build_sieve_client(config, name, account_config)?;
+                cmd.execute(printer, &mut account, &mut client)
             }
 
             // --- Meta

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,10 @@ fn is_default_smtp_alpn(alpn: &[String]) -> bool {
     alpn == default_smtp_alpn().as_slice()
 }
 
+fn is_default_sieve_alpn(alpn: &[String]) -> bool {
+    alpn.is_empty()
+}
+
 fn is_default_jmap_alpn(alpn: &[String]) -> bool {
     alpn == default_jmap_alpn().as_slice()
 }
@@ -45,6 +49,10 @@ pub(crate) fn default_imap_alpn() -> Vec<String> {
 
 pub(crate) fn default_smtp_alpn() -> Vec<String> {
     vec![String::from("smtp")]
+}
+
+pub(crate) fn default_sieve_alpn() -> Vec<String> {
+    Vec::new()
 }
 
 pub(crate) fn default_jmap_alpn() -> Vec<String> {
@@ -126,7 +134,7 @@ impl TomlConfig for Config {
 /// A key outside this list still renders, after the ones listed, so a
 /// field added to [`AccountConfig`] can never go missing from a
 /// generated document just because nobody updated this table.
-const RENDER_ORDER: [&str; 17] = [
+const RENDER_ORDER: [&str; 18] = [
     "default",
     "email",
     "display-name",
@@ -140,6 +148,7 @@ const RENDER_ORDER: [&str; 17] = [
     "m2dir",
     "pimdir",
     "smtp",
+    "sieve",
     "mailbox",
     "envelope",
     "attachment",
@@ -293,6 +302,8 @@ pub struct AccountConfig {
     pub pimdir: Option<PimdirConfig>,
     #[allow(unused)]
     pub smtp: Option<SmtpConfig>,
+    #[allow(unused)]
+    pub sieve: Option<SieveConfig>,
 }
 
 /// Envelope-level rendering options.
@@ -692,6 +703,36 @@ pub struct SmtpConfig {
     pub sasl: Option<SaslConfig>,
 }
 
+/// ManageSieve configuration.
+#[allow(unused)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct SieveConfig {
+    /// ManageSieve server address. Either a bare authority
+    /// (`sieve.example.com[:port]`, treated as `sieves://<authority>` by
+    /// default), a full `sieve://` URL for cleartext/STARTTLS, a
+    /// `sieves://` URL for implicit TLS, or a `unix://` socket.
+    pub server: String,
+
+    #[serde(default)]
+    pub tls: TlsConfig,
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub starttls: bool,
+
+    /// ManageSieve has no registered ALPN identifier, so the default is
+    /// an empty list. Set this explicitly when a server requires a private
+    /// ALPN protocol identifier.
+    #[serde(
+        default = "default_sieve_alpn",
+        skip_serializing_if = "is_default_sieve_alpn"
+    )]
+    pub alpn: Vec<String>,
+
+    /// Optional SASL credentials. The current client supports LOGIN and
+    /// PLAIN; other configured mechanisms are reported as unsupported.
+    pub sasl: Option<SaslConfig>,
+}
+
 /// SSL/TLS configuration.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
@@ -1069,6 +1110,22 @@ mod tests {
             config.keywords.header,
             Some(MaildirKeywordHeaderConfig::XLabel)
         );
+    }
+
+    #[test]
+    fn sieve_config_defaults_to_no_alpn() {
+        let config: SieveConfig = toml::from_str(
+            r#"
+                server = "sieve.example.com:4190"
+                starttls = true
+            "#,
+        )
+        .unwrap();
+
+        assert_eq!(config.server, "sieve.example.com:4190");
+        assert!(config.starttls);
+        assert!(config.alpn.is_empty());
+        assert!(config.sasl.is_none());
     }
 
     #[test]

--- a/src/json_schema.rs
+++ b/src/json_schema.rs
@@ -124,6 +124,18 @@ pub fn schemas() -> BTreeMap<String, Value> {
         insert!("himalaya-imap-fetch", crate::imap::fetch::FetchedMessages);
     }
 
+    // --- ManageSieve
+
+    #[cfg(feature = "sieve")]
+    {
+        insert!(
+            "himalaya-sieve-capability",
+            crate::sieve::capability::SieveCapabilities
+        );
+        insert!("himalaya-sieve-list", crate::sieve::list::SieveScripts);
+        insert!("himalaya-sieve-get", crate::sieve::get::SieveScriptOutput);
+    }
+
     // --- JMAP
 
     #[cfg(feature = "jmap")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,8 @@
 //! ## Backends and plumbing
 //!
 //! The network backends are io-imap, io-jmap, io-gmail, io-msgraph and
-//! io-smtp; the local storage backends are io-maildir and io-m2dir.
+//! io-smtp; ManageSieve is implemented in the optional `sieve` module;
+//! the local storage backends are io-maildir and io-m2dir.
 //! Account discovery comes from io-pim-discovery (Mozilla autoconfig,
 //! PACC, RFC 6186 SRV, RFC 8620 JMAP resolve). The CLI plumbing (clap
 //! args, printer, logger), TOML config loading and the blocking stream
@@ -23,7 +24,7 @@
 //! shared API (mailbox, envelope, flag, message, attachment) is the
 //! cross-protocol least-common-denominator surface, behaving the same
 //! whatever backend serves the active account. The protocol-specific
-//! APIs (imap, jmap, gmail, msgraph, maildir, m2dir, smtp) each expose
+//! APIs (imap, jmap, gmail, msgraph, maildir, m2dir, smtp, sieve) each expose
 //! the full surface of one backend, including operations the shared API
 //! cannot model. The meta commands (account, completion, manual) cover
 //! account configuration, shell completions and man pages.
@@ -91,6 +92,8 @@ mod msgraph;
 #[cfg(feature = "pimdir")]
 mod pimdir;
 mod shared;
+#[cfg(feature = "sieve")]
+mod sieve;
 #[cfg(feature = "smtp")]
 mod smtp;
 mod wizard;

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -17,6 +17,6 @@ pub mod mailbox;
 pub mod message;
 #[cfg(any(feature = "gmail", feature = "msgraph"))]
 pub mod output;
-#[cfg(any(feature = "imap", feature = "smtp"))]
+#[cfg(any(feature = "imap", feature = "smtp", feature = "sieve"))]
 pub mod raw;
 pub mod table;

--- a/src/shared/raw.rs
+++ b/src/shared/raw.rs
@@ -1,4 +1,4 @@
-//! Reusable clap arg for raw protocol command input (IMAP/SMTP).
+//! Reusable clap arg for raw protocol command input (IMAP/SMTP/ManageSieve).
 //!
 //! A raw command typed on the shell arrives with backslash escapes
 //! left literal (e.g. `a0 NOOP\r\n` reaches the process as the bytes

--- a/src/sieve/activate.rs
+++ b/src/sieve/activate.rs
@@ -1,0 +1,19 @@
+use anyhow::Result;
+use clap::Parser;
+use pimalaya_cli::printer::{Message, Printer};
+
+use crate::sieve::client::SieveClient;
+
+/// Make one server-side Sieve script active.
+#[derive(Debug, Parser)]
+pub struct SieveScriptActivateCommand {
+    #[arg(value_name = "NAME")]
+    pub name: String,
+}
+
+impl SieveScriptActivateCommand {
+    pub fn execute(self, printer: &mut impl Printer, client: &mut SieveClient) -> Result<()> {
+        client.set_active(Some(&self.name))?;
+        printer.out(Message::new("Sieve script successfully activated"))
+    }
+}

--- a/src/sieve/capability.rs
+++ b/src/sieve/capability.rs
@@ -1,0 +1,63 @@
+use std::fmt;
+
+use anyhow::Result;
+use clap::Parser;
+use comfy_table::{Cell, ContentArrangement, Row, Table};
+use pimalaya_cli::printer::Printer;
+use schemars::JsonSchema;
+use serde::Serialize;
+
+use crate::{
+    account::context::Account,
+    shared::table::style_from_preset,
+    sieve::{client::SieveClient, protocol::SieveCapability},
+};
+
+/// Query and print the server's current ManageSieve capabilities.
+#[derive(Debug, Parser)]
+pub struct SieveCapabilityListCommand;
+
+impl SieveCapabilityListCommand {
+    pub fn execute(
+        self,
+        printer: &mut impl Printer,
+        account: &Account,
+        client: &mut SieveClient,
+    ) -> Result<()> {
+        printer.out(SieveCapabilities {
+            preset: account.table_preset().to_string(),
+            arrangement: account.table_arrangement(),
+            capabilities: client.capability()?,
+        })
+    }
+}
+
+/// Structured output for `sieve capability`.
+#[derive(Clone, Debug, Serialize, JsonSchema)]
+pub struct SieveCapabilities {
+    #[serde(skip)]
+    pub preset: String,
+    #[serde(skip)]
+    pub arrangement: ContentArrangement,
+    pub capabilities: Vec<SieveCapability>,
+}
+
+impl fmt::Display for SieveCapabilities {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut table = Table::new();
+        table
+            .load_style(style_from_preset(&self.preset))
+            .set_content_arrangement(self.arrangement.clone())
+            .set_header(Row::from([Cell::new("CAPABILITY"), Cell::new("VALUES")]));
+
+        for capability in &self.capabilities {
+            table.add_row(Row::from([
+                Cell::new(&capability.name),
+                Cell::new(capability.values.join(" ")),
+            ]));
+        }
+
+        writeln!(f)?;
+        write!(f, "{table}")
+    }
+}

--- a/src/sieve/check.rs
+++ b/src/sieve/check.rs
@@ -1,0 +1,19 @@
+use anyhow::Result;
+use clap::Parser;
+use pimalaya_cli::printer::{Message, Printer};
+
+use crate::sieve::{client::SieveClient, script::SieveScriptArg};
+
+/// Validate a Sieve script on the server without storing it.
+#[derive(Debug, Parser)]
+pub struct SieveScriptCheckCommand {
+    #[command(flatten)]
+    pub script: SieveScriptArg,
+}
+
+impl SieveScriptCheckCommand {
+    pub fn execute(self, printer: &mut impl Printer, client: &mut SieveClient) -> Result<()> {
+        client.check_script(&self.script.read()?)?;
+        printer.out(Message::new("Sieve script is valid"))
+    }
+}

--- a/src/sieve/cli.rs
+++ b/src/sieve/cli.rs
@@ -1,0 +1,60 @@
+use anyhow::Result;
+use clap::Subcommand;
+use pimalaya_cli::printer::Printer;
+
+use crate::{
+    account::context::Account,
+    sieve::{
+        activate::SieveScriptActivateCommand, capability::SieveCapabilityListCommand,
+        check::SieveScriptCheckCommand, client::SieveClient,
+        deactivate::SieveScriptDeactivateCommand, delete::SieveScriptDeleteCommand,
+        get::SieveScriptGetCommand, list::SieveScriptListCommand, put::SieveScriptPutCommand,
+        raw::SieveRawCommand,
+    },
+};
+
+/// Manage server-side Sieve scripts through RFC 5804 ManageSieve.
+#[derive(Debug, Subcommand)]
+#[command(rename_all = "kebab-case")]
+pub enum SieveCommand {
+    /// Query server capabilities.
+    #[command(alias = "capabilities")]
+    Capability(SieveCapabilityListCommand),
+    /// List installed scripts.
+    List(SieveScriptListCommand),
+    /// Download one script.
+    Get(SieveScriptGetCommand),
+    /// Validate capacity and upload one script.
+    Put(SieveScriptPutCommand),
+    /// Validate a script without storing it.
+    Check(SieveScriptCheckCommand),
+    /// Activate one script.
+    Activate(SieveScriptActivateCommand),
+    /// Disable the active script.
+    Deactivate(SieveScriptDeactivateCommand),
+    /// Delete one script.
+    Delete(SieveScriptDeleteCommand),
+    /// Send one raw command line.
+    Raw(SieveRawCommand),
+}
+
+impl SieveCommand {
+    pub fn execute(
+        self,
+        printer: &mut impl Printer,
+        account: &mut Account,
+        client: &mut SieveClient,
+    ) -> Result<()> {
+        match self {
+            Self::Capability(cmd) => cmd.execute(printer, account, client),
+            Self::List(cmd) => cmd.execute(printer, account, client),
+            Self::Get(cmd) => cmd.execute(printer, client),
+            Self::Put(cmd) => cmd.execute(printer, client),
+            Self::Check(cmd) => cmd.execute(printer, client),
+            Self::Activate(cmd) => cmd.execute(printer, client),
+            Self::Deactivate(cmd) => cmd.execute(printer, client),
+            Self::Delete(cmd) => cmd.execute(printer, client),
+            Self::Raw(cmd) => cmd.execute(printer, client),
+        }
+    }
+}

--- a/src/sieve/client.rs
+++ b/src/sieve/client.rs
@@ -1,0 +1,536 @@
+use std::io::{Read, Write};
+
+use anyhow::{Result, anyhow, bail};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
+use io_sasl::{
+    coroutine::{SaslArg, SaslCoroutine, SaslCoroutineState, SaslYield},
+    login::{SaslLogin, SaslLoginCreds},
+    mechanism::Sasl,
+    rfc4616::plain::{SaslPlain, SaslPlainCreds},
+};
+use pimalaya_stream::stream::{Stream, TcpConnectOptions, TlsConnectOptions, UnixConnectOptions};
+use url::Url;
+
+use crate::{
+    account::context::Account,
+    config::{AccountConfig, Config, SieveConfig, parse_server},
+    sieve::protocol::{
+        SieveCapability, SieveData, SieveResponse, SieveScript, literal_size, parse_capabilities,
+        parse_script, parse_string, parse_tokens, quote_string, status,
+    },
+};
+
+const DEFAULT_PORT: u16 = 4190;
+const MAX_LINE: usize = 1024 * 1024;
+const MAX_LITERAL: usize = 64 * 1024 * 1024;
+
+/// Blocking ManageSieve client implementing RFC 5804 framing and commands.
+pub struct SieveClient {
+    stream: Stream,
+    read_buffer: Vec<u8>,
+    capabilities: Vec<SieveCapability>,
+}
+
+impl SieveClient {
+    /// Opens a ManageSieve session, reads the greeting, upgrades with
+    /// STARTTLS when requested, and authenticates when configured.
+    pub fn new(config: SieveConfig) -> Result<Self> {
+        let server = parse_sieve_server(&config.server)?;
+        let tls = config.tls.into_tls(config.alpn);
+        let port = server.port().unwrap_or(DEFAULT_PORT);
+
+        if config.starttls && server.scheme() != "sieve" {
+            bail!("ManageSieve STARTTLS requires a `sieve://` server")
+        }
+
+        let stream = match server.scheme() {
+            "sieve" => Stream::connect_tcp(
+                server
+                    .host_str()
+                    .ok_or_else(|| anyhow!("ManageSieve server has no host: {server}"))?,
+                port,
+                TcpConnectOptions::default(),
+            )?,
+            "sieves" => Stream::connect_tls(
+                server
+                    .host_str()
+                    .ok_or_else(|| anyhow!("ManageSieve server has no host: {server}"))?,
+                port,
+                TlsConnectOptions {
+                    tls: tls.clone(),
+                    ..Default::default()
+                },
+            )?,
+            "unix" => Stream::connect_unix(
+                server
+                    .to_file_path()
+                    .map_err(|()| anyhow!("Invalid ManageSieve Unix socket URL: {server}"))?,
+                UnixConnectOptions::default(),
+            )?,
+            scheme => bail!("Invalid ManageSieve server scheme `{scheme}`"),
+        };
+
+        let mut client = Self {
+            stream,
+            read_buffer: Vec::new(),
+            capabilities: Vec::new(),
+        };
+
+        let greeting = client.read_response()?.ensure_ok("greeting")?;
+        client.set_capabilities(&greeting.data)?;
+
+        if config.starttls {
+            client.command(b"STARTTLS")?.ensure_ok("STARTTLS")?;
+            client.stream = client.stream.upgrade_tls(&tls)?;
+
+            // RFC 5804 requires the server to send a fresh capability
+            // response after TLS negotiation.
+            let capabilities = client.read_response()?.ensure_ok("TLS greeting")?;
+            client.set_capabilities(&capabilities.data)?;
+        }
+
+        if let Some(sasl_config) = config.sasl {
+            if server.scheme() == "unix" {
+                // A Unix socket can point at a pre-authenticated proxy,
+                // matching the IMAP/SMTP behavior in this repository.
+                return Ok(client);
+            }
+
+            let host = server
+                .host_str()
+                .ok_or_else(|| anyhow!("Cannot derive host from ManageSieve server `{server}`"))?;
+            let sasl = sasl_config.try_into_sasl(host, port)?;
+            if server.scheme() == "sieve"
+                && !config.starttls
+                && matches!(sasl, Sasl::Login(_) | Sasl::Plain(_))
+            {
+                bail!("ManageSieve LOGIN and PLAIN authentication require TLS")
+            }
+            client.authenticate(sasl)?;
+        }
+
+        Ok(client)
+    }
+
+    pub fn capability(&mut self) -> Result<Vec<SieveCapability>> {
+        let response = self.command(b"CAPABILITY")?.ensure_ok("CAPABILITY")?;
+        self.set_capabilities(&response.data)?;
+        Ok(self.capabilities.clone())
+    }
+
+    pub fn list_scripts(&mut self) -> Result<Vec<SieveScript>> {
+        let response = self.command(b"LISTSCRIPTS")?.ensure_ok("LISTSCRIPTS")?;
+        response.data.iter().map(parse_script).collect()
+    }
+
+    pub fn get_script(&mut self, name: &str) -> Result<Vec<u8>> {
+        let mut command = b"GETSCRIPT ".to_vec();
+        command.extend(quote_string(name.as_bytes())?);
+        let response = self.command(&command)?.ensure_ok("GETSCRIPT")?;
+        let item = response
+            .data
+            .first()
+            .ok_or_else(|| anyhow!("ManageSieve GETSCRIPT returned no script"))?;
+        parse_string(item)
+    }
+
+    pub fn put_script(&mut self, name: &str, script: &[u8]) -> Result<()> {
+        let mut have_space = b"HAVESPACE ".to_vec();
+        have_space.extend(quote_string(name.as_bytes())?);
+        have_space.extend_from_slice(format!(" {}", script.len()).as_bytes());
+        self.command(&have_space)?.ensure_ok("HAVESPACE")?;
+
+        let mut prefix = b"PUTSCRIPT ".to_vec();
+        prefix.extend(quote_string(name.as_bytes())?);
+        self.literal_command(&prefix, script)?
+            .ensure_ok("PUTSCRIPT")?;
+        Ok(())
+    }
+
+    pub fn check_script(&mut self, script: &[u8]) -> Result<()> {
+        self.literal_command(b"CHECKSCRIPT", script)?
+            .ensure_ok("CHECKSCRIPT")?;
+        Ok(())
+    }
+
+    pub fn set_active(&mut self, name: Option<&str>) -> Result<()> {
+        let mut command = b"SETACTIVE ".to_vec();
+        command.extend(quote_string(name.unwrap_or_default().as_bytes())?);
+        self.command(&command)?.ensure_ok("SETACTIVE")?;
+        Ok(())
+    }
+
+    pub fn delete_script(&mut self, name: &str) -> Result<()> {
+        let mut command = b"DELETESCRIPT ".to_vec();
+        command.extend(quote_string(name.as_bytes())?);
+        self.command(&command)?.ensure_ok("DELETESCRIPT")?;
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub fn logout(&mut self) -> Result<()> {
+        self.command(b"LOGOUT")?.ensure_ok("LOGOUT")?;
+        Ok(())
+    }
+
+    /// Sends one raw command line and renders its complete response.
+    /// Literal-bearing commands belong to the high-level methods above;
+    /// raw is intentionally limited to one line so it cannot desync the
+    /// response reader with an unframed batch.
+    pub fn raw(&mut self, command: &str) -> Result<String> {
+        let command = command.trim_end_matches(['\r', '\n']);
+        if command.contains('\r') || command.contains('\n') {
+            bail!("ManageSieve raw accepts a single command line")
+        }
+        if command.trim().is_empty() {
+            bail!("ManageSieve raw command is empty")
+        }
+
+        Ok(self.command(command.as_bytes())?.to_text())
+    }
+
+    fn authenticate(&mut self, sasl: Sasl) -> Result<()> {
+        match sasl {
+            Sasl::Plain(creds) => self.authenticate_plain(creds),
+            Sasl::Login(creds) => self.authenticate_login(creds),
+            sasl => bail!(
+                "ManageSieve SASL mechanism `{}` is not supported; use LOGIN or PLAIN",
+                sasl.mechanism().as_str()
+            ),
+        }
+    }
+
+    fn authenticate_plain(&mut self, creds: SaslPlainCreds) -> Result<()> {
+        let mut mechanism = SaslPlain::new(creds);
+        let payload = wants_write(mechanism.resume(SaslArg::None))?;
+        let encoded = STANDARD.encode(payload);
+        let mut command = b"AUTHENTICATE \"PLAIN\" ".to_vec();
+        command.extend(quote_string(encoded.as_bytes())?);
+        let response = self.command(&command)?.ensure_ok("AUTHENTICATE PLAIN")?;
+        complete_sasl(&mut mechanism)?;
+        self.set_capabilities(&response.data)?;
+        Ok(())
+    }
+
+    fn authenticate_login(&mut self, creds: SaslLoginCreds) -> Result<()> {
+        let mut mechanism = SaslLogin::new(creds);
+        self.write_line(b"AUTHENTICATE \"LOGIN\"")?;
+        let _challenge = self.read_auth_challenge()?;
+
+        let username = wants_write(mechanism.resume(SaslArg::None))?;
+        self.write_auth_response(&username)?;
+        let challenge = self.read_auth_challenge()?;
+
+        let password = wants_write(mechanism.resume(SaslArg::Input(&challenge)))?;
+        self.write_auth_response(&password)?;
+        let response = self.read_response()?.ensure_ok("AUTHENTICATE LOGIN")?;
+        complete_sasl(&mut mechanism)?;
+        self.set_capabilities(&response.data)?;
+        Ok(())
+    }
+
+    fn write_auth_response(&mut self, payload: &[u8]) -> Result<()> {
+        let encoded = STANDARD.encode(payload);
+        let command = quote_string(encoded.as_bytes())?;
+        self.write_line(&command)
+    }
+
+    fn read_auth_challenge(&mut self) -> Result<Vec<u8>> {
+        let line = self.read_line()?;
+        if let Some(status) = status(&line) {
+            bail!(
+                "ManageSieve authentication ended with {}: {}",
+                status.as_str(),
+                String::from_utf8_lossy(&line)
+            )
+        }
+
+        if let Some(size) = literal_size(&line) {
+            let (literal, suffix) = self.read_literal(size)?;
+            if !suffix.is_empty() {
+                bail!("invalid ManageSieve authentication challenge")
+            }
+            return Ok(literal);
+        }
+
+        let tokens = parse_tokens(&line)?;
+        if tokens.len() != 1 {
+            bail!("invalid ManageSieve authentication challenge")
+        }
+        Ok(tokens[0].clone())
+    }
+
+    fn set_capabilities(&mut self, data: &[SieveData]) -> Result<()> {
+        if !data.is_empty() {
+            self.capabilities = parse_capabilities(data)?;
+        }
+        Ok(())
+    }
+
+    fn command(&mut self, command: &[u8]) -> Result<SieveResponse> {
+        self.write_line(command)?;
+        self.read_response()
+    }
+
+    fn literal_command(&mut self, prefix: &[u8], value: &[u8]) -> Result<SieveResponse> {
+        let mut header = prefix.to_vec();
+        header.extend_from_slice(format!(" {{{}+}}", value.len()).as_bytes());
+        self.write_line(&header)?;
+        self.stream.write_all(value)?;
+        self.stream.write_all(b"\r\n")?;
+        self.stream.flush()?;
+        self.read_response()
+    }
+
+    fn write_line(&mut self, line: &[u8]) -> Result<()> {
+        if line.contains(&b'\r') || line.contains(&b'\n') {
+            bail!("ManageSieve command contains an unexpected newline")
+        }
+        self.stream.write_all(line)?;
+        self.stream.write_all(b"\r\n")?;
+        self.stream.flush()?;
+        Ok(())
+    }
+
+    fn read_response(&mut self) -> Result<SieveResponse> {
+        let mut data = Vec::new();
+
+        loop {
+            let line = self.read_line()?;
+            if let Some(response_status) = status(&line) {
+                let mut detail = line.clone();
+                if let Some(size) = literal_size(&line) {
+                    let (literal, suffix) = self.read_literal(size)?;
+                    detail.extend_from_slice(b" ");
+                    detail.extend_from_slice(&literal);
+                    detail.extend_from_slice(&suffix);
+                }
+                return Ok(SieveResponse {
+                    data,
+                    status: response_status,
+                    detail,
+                });
+            }
+
+            if let Some((start, size)) = crate::sieve::protocol::literal_marker(&line) {
+                let prefix = line[..start].trim_ascii_end().to_vec();
+                let (literal, suffix) = self.read_literal(size)?;
+                data.push(SieveData::literal(prefix, literal, suffix));
+            } else {
+                data.push(SieveData::line(line));
+            }
+        }
+    }
+
+    fn read_literal(&mut self, size: usize) -> Result<(Vec<u8>, Vec<u8>)> {
+        ensure_literal_size(size)?;
+        let mut bytes = vec![0; size];
+        self.read_exact(&mut bytes)?;
+        Ok((bytes, self.read_line()?))
+    }
+
+    fn read_exact(&mut self, output: &mut [u8]) -> Result<()> {
+        let mut offset = 0;
+        while offset < output.len() {
+            if !self.read_buffer.is_empty() {
+                let count = (output.len() - offset).min(self.read_buffer.len());
+                output[offset..offset + count].copy_from_slice(&self.read_buffer[..count]);
+                self.read_buffer.drain(..count);
+                offset += count;
+                continue;
+            }
+
+            let mut chunk = [0; 8192];
+            let count = self.stream.read(&mut chunk)?;
+            if count == 0 {
+                bail!("ManageSieve connection closed while reading a literal")
+            }
+            self.read_buffer.extend_from_slice(&chunk[..count]);
+        }
+        Ok(())
+    }
+
+    fn read_line(&mut self) -> Result<Vec<u8>> {
+        loop {
+            if let Some(index) = self.read_buffer.iter().position(|&byte| byte == b'\n') {
+                if index > MAX_LINE {
+                    bail!("ManageSieve response line exceeds {MAX_LINE} bytes")
+                }
+                let mut line = self.read_buffer.drain(..=index).collect::<Vec<_>>();
+                line.pop();
+                if line.last() == Some(&b'\r') {
+                    line.pop();
+                }
+                return Ok(line);
+            }
+
+            if self.read_buffer.len() > MAX_LINE {
+                bail!("ManageSieve response line exceeds {MAX_LINE} bytes")
+            }
+
+            let mut chunk = [0; 8192];
+            let count = self.stream.read(&mut chunk)?;
+            if count == 0 {
+                bail!("ManageSieve connection closed before a CRLF response")
+            }
+            self.read_buffer.extend_from_slice(&chunk[..count]);
+        }
+    }
+}
+
+fn ensure_literal_size(size: usize) -> Result<()> {
+    if size > MAX_LITERAL {
+        bail!("ManageSieve literal exceeds {MAX_LITERAL} bytes")
+    }
+    Ok(())
+}
+
+/// Parses a ManageSieve server string into a URL.
+pub fn parse_sieve_server(server: &str) -> Result<Url> {
+    parse_server(server, "sieves", &["sieve", "sieves", "unix"])
+}
+
+/// Opens the Sieve session for an already-resolved account.
+pub fn build_sieve_client(
+    config: Config,
+    name: String,
+    mut account_config: AccountConfig,
+) -> Result<(Account, SieveClient)> {
+    let sieve_config = account_config
+        .sieve
+        .take()
+        .ok_or_else(|| anyhow!("Sieve config is missing for account `{name}`"))?;
+    let account = Account::from(config).merge(Account::from(account_config));
+    let client = SieveClient::new(sieve_config)?;
+    Ok((account, client))
+}
+
+fn wants_write<E>(state: SaslCoroutineState<SaslYield, Result<(), E>>) -> Result<Vec<u8>>
+where
+    E: std::error::Error + Send + Sync + 'static,
+{
+    match state {
+        SaslCoroutineState::Yielded(SaslYield::WantsWrite(payload)) => Ok(payload),
+        SaslCoroutineState::Yielded(SaslYield::WantsRead) => {
+            bail!("ManageSieve SASL mechanism unexpectedly requested a read")
+        }
+        SaslCoroutineState::Complete(result) => result.map(|()| Vec::new()).map_err(Into::into),
+    }
+}
+
+fn complete_sasl<M>(mechanism: &mut M) -> Result<()>
+where
+    M: SaslCoroutine,
+    M::Error: std::error::Error + Send + Sync + 'static,
+{
+    match mechanism.resume(SaslArg::Done) {
+        SaslCoroutineState::Complete(result) => result.map_err(Into::into),
+        SaslCoroutineState::Yielded(_) => bail!("ManageSieve SASL exchange did not complete"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        io::{BufRead, BufReader, Read, Write},
+        net::{TcpListener, TcpStream},
+        thread,
+    };
+
+    use super::*;
+
+    #[test]
+    fn exercises_literal_commands_against_a_local_server() {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = thread::spawn(move || fake_server(listener));
+
+        let config = SieveConfig {
+            server: format!("sieve://{address}"),
+            tls: Default::default(),
+            starttls: false,
+            alpn: Vec::new(),
+            sasl: None,
+        };
+        let mut client = SieveClient::new(config).unwrap();
+        assert_eq!(client.list_scripts().unwrap()[1].name, "vacation script");
+        assert_eq!(
+            client.get_script("main").unwrap(),
+            b"require [\"fileinto\"];\n"
+        );
+        client
+            .put_script("new", b"require [\"fileinto\"];\n")
+            .unwrap();
+        client.check_script(b"require [\"fileinto\"];\n").unwrap();
+        client.set_active(Some("new")).unwrap();
+        client.delete_script("new").unwrap();
+        client.logout().unwrap();
+
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn rejects_oversized_literals_before_allocating() {
+        assert!(ensure_literal_size(MAX_LITERAL + 1).is_err());
+        ensure_literal_size(MAX_LITERAL).unwrap();
+    }
+
+    fn fake_server(listener: TcpListener) {
+        let (stream, _) = listener.accept().unwrap();
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+        let mut writer = stream;
+        write_capabilities(&mut writer);
+
+        loop {
+            let mut line = String::new();
+            if reader.read_line(&mut line).unwrap() == 0 {
+                return;
+            }
+            let command = line.trim_end_matches(['\r', '\n']);
+            if command == "LISTSCRIPTS" {
+                writer
+                    .write_all(b"\"main\"\r\n{15}\r\nvacation script\r\n ACTIVE\r\nOK\r\n")
+                    .unwrap();
+            } else if command == "GETSCRIPT \"main\"" {
+                let script = b"require [\"fileinto\"];\n";
+                write!(writer, "{{{}}}\r\n", script.len()).unwrap();
+                writer.write_all(script).unwrap();
+                writer.write_all(b"\r\nOK\r\n").unwrap();
+            } else if command.starts_with("HAVESPACE ") {
+                writer.write_all(b"OK\r\n").unwrap();
+            } else if command.starts_with("PUTSCRIPT ") || command.starts_with("CHECKSCRIPT ") {
+                let size = line_literal_size(command.as_bytes());
+                let mut script = vec![0; size];
+                reader.read_exact(&mut script).unwrap();
+                let mut terminator = String::new();
+                reader.read_line(&mut terminator).unwrap();
+                writer.write_all(b"OK\r\n").unwrap();
+            } else if command.starts_with("SETACTIVE ") || command.starts_with("DELETESCRIPT ") {
+                writer.write_all(b"OK\r\n").unwrap();
+            } else if command == "LOGOUT" {
+                writer.write_all(b"OK\r\n").unwrap();
+                return;
+            } else {
+                panic!("unexpected fake ManageSieve command: {command}");
+            }
+            writer.flush().unwrap();
+        }
+    }
+
+    fn write_capabilities(writer: &mut TcpStream) {
+        writer
+            .write_all(b"\"IMPLEMENTATION\" \"fake\"\r\n\"SIEVE\" \"fileinto vacation\"\r\nOK\r\n")
+            .unwrap();
+        writer.flush().unwrap();
+    }
+
+    fn line_literal_size(line: &[u8]) -> usize {
+        let start = line.iter().rposition(|&byte| byte == b'{').unwrap();
+        let end = line.iter().rposition(|&byte| byte == b'}').unwrap();
+        std::str::from_utf8(&line[start + 1..end])
+            .unwrap()
+            .trim_end_matches('+')
+            .parse()
+            .unwrap()
+    }
+}

--- a/src/sieve/deactivate.rs
+++ b/src/sieve/deactivate.rs
@@ -1,0 +1,16 @@
+use anyhow::Result;
+use clap::Parser;
+use pimalaya_cli::printer::{Message, Printer};
+
+use crate::sieve::client::SieveClient;
+
+/// Disable the currently active server-side Sieve script.
+#[derive(Debug, Parser)]
+pub struct SieveScriptDeactivateCommand;
+
+impl SieveScriptDeactivateCommand {
+    pub fn execute(self, printer: &mut impl Printer, client: &mut SieveClient) -> Result<()> {
+        client.set_active(None)?;
+        printer.out(Message::new("Sieve script successfully deactivated"))
+    }
+}

--- a/src/sieve/delete.rs
+++ b/src/sieve/delete.rs
@@ -1,0 +1,19 @@
+use anyhow::Result;
+use clap::Parser;
+use pimalaya_cli::printer::{Message, Printer};
+
+use crate::sieve::client::SieveClient;
+
+/// Delete one server-side Sieve script.
+#[derive(Debug, Parser)]
+pub struct SieveScriptDeleteCommand {
+    #[arg(value_name = "NAME")]
+    pub name: String,
+}
+
+impl SieveScriptDeleteCommand {
+    pub fn execute(self, printer: &mut impl Printer, client: &mut SieveClient) -> Result<()> {
+        client.delete_script(&self.name)?;
+        printer.out(Message::new("Sieve script successfully deleted"))
+    }
+}

--- a/src/sieve/get.rs
+++ b/src/sieve/get.rs
@@ -1,0 +1,43 @@
+use std::fmt;
+
+use anyhow::Result;
+use clap::Parser;
+use pimalaya_cli::printer::Printer;
+use schemars::JsonSchema;
+use serde::Serialize;
+
+use crate::sieve::client::SieveClient;
+
+/// Download and print one server-side Sieve script.
+#[derive(Debug, Parser)]
+pub struct SieveScriptGetCommand {
+    /// The script name.
+    #[arg(value_name = "NAME")]
+    pub name: String,
+}
+
+impl SieveScriptGetCommand {
+    pub fn execute(self, printer: &mut impl Printer, client: &mut SieveClient) -> Result<()> {
+        let script = client.get_script(&self.name)?;
+        let script = String::from_utf8(script)
+            .map_err(|_| anyhow::anyhow!("ManageSieve script is not valid UTF-8"))?;
+        printer.out(SieveScriptOutput {
+            name: self.name,
+            script,
+        })
+    }
+}
+
+/// Structured output for `sieve get`.
+#[derive(Clone, Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub struct SieveScriptOutput {
+    pub name: String,
+    pub script: String,
+}
+
+impl fmt::Display for SieveScriptOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.script)
+    }
+}

--- a/src/sieve/list.rs
+++ b/src/sieve/list.rs
@@ -1,0 +1,63 @@
+use std::fmt;
+
+use anyhow::Result;
+use clap::Parser;
+use comfy_table::{Cell, ContentArrangement, Row, Table};
+use pimalaya_cli::printer::Printer;
+use schemars::JsonSchema;
+use serde::Serialize;
+
+use crate::{
+    account::context::Account,
+    shared::table::style_from_preset,
+    sieve::{client::SieveClient, protocol::SieveScript},
+};
+
+/// List all server-side Sieve scripts and mark the active script.
+#[derive(Debug, Parser)]
+pub struct SieveScriptListCommand;
+
+impl SieveScriptListCommand {
+    pub fn execute(
+        self,
+        printer: &mut impl Printer,
+        account: &Account,
+        client: &mut SieveClient,
+    ) -> Result<()> {
+        printer.out(SieveScripts {
+            preset: account.table_preset().to_string(),
+            arrangement: account.table_arrangement(),
+            scripts: client.list_scripts()?,
+        })
+    }
+}
+
+/// Structured output for `sieve list`.
+#[derive(Clone, Debug, Serialize, JsonSchema)]
+pub struct SieveScripts {
+    #[serde(skip)]
+    pub preset: String,
+    #[serde(skip)]
+    pub arrangement: ContentArrangement,
+    pub scripts: Vec<SieveScript>,
+}
+
+impl fmt::Display for SieveScripts {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut table = Table::new();
+        table
+            .load_style(style_from_preset(&self.preset))
+            .set_content_arrangement(self.arrangement.clone())
+            .set_header(Row::from([Cell::new("NAME"), Cell::new("ACTIVE")]));
+
+        for script in &self.scripts {
+            table.add_row(Row::from([
+                Cell::new(&script.name),
+                Cell::new(if script.active { "yes" } else { "" }),
+            ]));
+        }
+
+        writeln!(f)?;
+        write!(f, "{table}")
+    }
+}

--- a/src/sieve/mod.rs
+++ b/src/sieve/mod.rs
@@ -1,0 +1,13 @@
+pub mod activate;
+pub mod capability;
+pub mod check;
+pub mod cli;
+pub mod client;
+pub mod deactivate;
+pub mod delete;
+pub mod get;
+pub mod list;
+pub mod protocol;
+pub mod put;
+pub mod raw;
+pub mod script;

--- a/src/sieve/protocol.rs
+++ b/src/sieve/protocol.rs
@@ -1,0 +1,384 @@
+use std::{fmt, str};
+
+use anyhow::{Result, bail};
+use schemars::JsonSchema;
+use serde::Serialize;
+
+/// A capability advertised by a ManageSieve server.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub struct SieveCapability {
+    pub name: String,
+    pub values: Vec<String>,
+}
+
+/// One script name returned by `LISTSCRIPTS`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(rename_all = "kebab-case")]
+pub struct SieveScript {
+    pub name: String,
+    pub active: bool,
+}
+
+/// The final status of one ManageSieve command response.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SieveStatus {
+    Ok,
+    No,
+    Bye,
+}
+
+impl SieveStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Ok => "OK",
+            Self::No => "NO",
+            Self::Bye => "BYE",
+        }
+    }
+}
+
+/// One logical data line in a server response.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SieveData {
+    /// The decoded value for a literal, or the raw response line for a
+    /// quoted/atom response item.
+    pub bytes: Vec<u8>,
+    /// Whether `bytes` came from a RFC 5804 literal. Non-literal data
+    /// keeps its original line in `bytes` so callers can parse strings
+    /// and atoms without losing their framing.
+    pub literal: bool,
+    /// Tokens that preceded a literal marker on the response line.
+    prefix: Vec<u8>,
+    /// Tokens that followed the literal payload on its terminating line.
+    suffix: Vec<u8>,
+}
+
+impl SieveData {
+    pub fn line(bytes: Vec<u8>) -> Self {
+        Self {
+            bytes,
+            literal: false,
+            prefix: Vec::new(),
+            suffix: Vec::new(),
+        }
+    }
+
+    pub fn literal(prefix: Vec<u8>, bytes: Vec<u8>, suffix: Vec<u8>) -> Self {
+        Self {
+            bytes,
+            literal: true,
+            prefix,
+            suffix,
+        }
+    }
+
+    /// Decodes the strings and atoms in this logical response line.
+    /// Literal payloads are one string token even when they contain spaces,
+    /// quotes, or newlines.
+    pub fn tokens(&self) -> Result<Vec<Vec<u8>>> {
+        if !self.literal {
+            return parse_tokens(&self.bytes);
+        }
+
+        let mut tokens = parse_tokens(&self.prefix)?;
+        tokens.push(self.bytes.clone());
+        tokens.extend(parse_tokens(&self.suffix)?);
+        Ok(tokens)
+    }
+
+    /// Renders the logical line for the diagnostic raw command.
+    pub fn to_text(&self) -> Vec<u8> {
+        if !self.literal {
+            return self.bytes.clone();
+        }
+
+        let mut line = self.prefix.clone();
+        if !line.is_empty() {
+            line.push(b' ');
+        }
+        line.extend_from_slice(&self.bytes);
+        line.extend_from_slice(&self.suffix);
+        line
+    }
+}
+
+/// A complete response: zero or more data items followed by a status.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SieveResponse {
+    pub data: Vec<SieveData>,
+    pub status: SieveStatus,
+    pub detail: Vec<u8>,
+}
+
+impl SieveResponse {
+    pub fn ensure_ok(self, operation: &str) -> Result<Self> {
+        if self.status != SieveStatus::Ok {
+            let detail = String::from_utf8_lossy(&self.detail);
+            bail!(
+                "ManageSieve {operation} failed with {}{}",
+                self.status.as_str(),
+                if detail.is_empty() {
+                    String::new()
+                } else {
+                    format!(": {detail}")
+                }
+            );
+        }
+
+        Ok(self)
+    }
+
+    /// Renders a diagnostic response for `sieve raw` while retaining
+    /// literal payloads as bytes and separating response items by lines.
+    pub fn to_text(&self) -> String {
+        let mut lines = Vec::new();
+        for item in &self.data {
+            lines.push(String::from_utf8_lossy(&item.to_text()).into_owned());
+        }
+        if !self.detail.is_empty() {
+            lines.push(String::from_utf8_lossy(&self.detail).into_owned());
+        } else {
+            lines.push(self.status.as_str().to_string());
+        }
+        lines.join("\n")
+    }
+}
+
+impl fmt::Display for SieveCapability {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.values.is_empty() {
+            write!(f, "{}", self.name)
+        } else {
+            write!(f, "{} {}", self.name, self.values.join(" "))
+        }
+    }
+}
+
+/// Parses a ManageSieve quoted-string/atom line into tokens.
+pub fn parse_tokens(line: &[u8]) -> Result<Vec<Vec<u8>>> {
+    let mut tokens = Vec::new();
+    let mut index = 0;
+
+    while index < line.len() {
+        while line.get(index).is_some_and(u8::is_ascii_whitespace) {
+            index += 1;
+        }
+        if index == line.len() {
+            break;
+        }
+
+        if line[index] == b'"' {
+            index += 1;
+            let mut token = Vec::new();
+            let mut closed = false;
+
+            while index < line.len() {
+                match line[index] {
+                    b'"' => {
+                        index += 1;
+                        closed = true;
+                        break;
+                    }
+                    b'\\' => {
+                        index += 1;
+                        let Some(byte) = line.get(index).copied() else {
+                            bail!("unterminated ManageSieve quoted string")
+                        };
+                        token.push(byte);
+                        index += 1;
+                    }
+                    byte => {
+                        if byte == b'\r' || byte == b'\n' {
+                            bail!("newline in ManageSieve quoted string")
+                        }
+                        token.push(byte);
+                        index += 1;
+                    }
+                }
+            }
+
+            if !closed {
+                bail!("unterminated ManageSieve quoted string")
+            }
+            tokens.push(token);
+        } else {
+            let start = index;
+            while line
+                .get(index)
+                .is_some_and(|byte| !byte.is_ascii_whitespace())
+            {
+                index += 1;
+            }
+            tokens.push(line[start..index].to_vec());
+        }
+    }
+
+    Ok(tokens)
+}
+
+/// Quotes a string for a ManageSieve command.
+pub fn quote_string(value: &[u8]) -> Result<Vec<u8>> {
+    let mut quoted = Vec::with_capacity(value.len() + 2);
+    quoted.push(b'"');
+
+    for &byte in value {
+        if byte == b'\r' || byte == b'\n' || byte == 0 || byte < 0x20 {
+            bail!("ManageSieve quoted strings cannot contain control characters")
+        }
+        if byte == b'"' || byte == b'\\' {
+            quoted.push(b'\\');
+        }
+        quoted.push(byte);
+    }
+
+    quoted.push(b'"');
+    Ok(quoted)
+}
+
+pub fn parse_capabilities(items: &[SieveData]) -> Result<Vec<SieveCapability>> {
+    items
+        .iter()
+        .map(|item| {
+            let tokens = item.tokens()?;
+            let Some(name) = tokens.first() else {
+                bail!("empty ManageSieve capability response")
+            };
+            let name = str::from_utf8(name)
+                .map_err(|_| anyhow::anyhow!("ManageSieve capability name is not UTF-8"))?
+                .to_string();
+
+            let mut values = Vec::new();
+            for value in tokens.iter().skip(1) {
+                let value = str::from_utf8(value)
+                    .map_err(|_| anyhow::anyhow!("ManageSieve capability value is not UTF-8"))?;
+                values.extend(value.split_whitespace().map(str::to_owned));
+            }
+
+            Ok(SieveCapability { name, values })
+        })
+        .collect()
+}
+
+pub fn parse_script(item: &SieveData) -> Result<SieveScript> {
+    let tokens = item.tokens()?;
+    let Some(name) = tokens.first() else {
+        bail!("empty ManageSieve script response")
+    };
+    let name = str::from_utf8(name)
+        .map_err(|_| anyhow::anyhow!("ManageSieve script name is not UTF-8"))?
+        .to_string();
+    let active = tokens
+        .iter()
+        .skip(1)
+        .any(|token| token.eq_ignore_ascii_case(b"ACTIVE"));
+
+    Ok(SieveScript { name, active })
+}
+
+/// Decodes a response item that contains one ManageSieve string.
+pub fn parse_string(item: &SieveData) -> Result<Vec<u8>> {
+    let tokens = item.tokens()?;
+    if tokens.len() != 1 {
+        bail!("expected one ManageSieve string response")
+    }
+    Ok(tokens[0].clone())
+}
+
+/// Finds a trailing `{size}` or `{size+}` literal marker.
+pub fn literal_size(line: &[u8]) -> Option<usize> {
+    literal_marker(line).map(|(_, size)| size)
+}
+
+/// Finds the start and size of a trailing `{size}` or `{size+}` marker.
+pub fn literal_marker(line: &[u8]) -> Option<(usize, usize)> {
+    let line = line.trim_ascii_end();
+    let end = line.len().checked_sub(1)?;
+    (line[end] == b'}').then_some(())?;
+    let start = line.iter().rposition(|&byte| byte == b'{')?;
+    if start > 0 && !line[start - 1].is_ascii_whitespace() {
+        return None;
+    }
+    let marker = &line[start + 1..end];
+    let marker = marker.strip_suffix(b"+").unwrap_or(marker);
+    if marker.is_empty() || !marker.iter().all(u8::is_ascii_digit) {
+        return None;
+    }
+    Some((start, str::from_utf8(marker).ok()?.parse().ok()?))
+}
+
+pub fn status(line: &[u8]) -> Option<SieveStatus> {
+    let token = line.split(|byte| byte.is_ascii_whitespace()).next()?;
+    if token.eq_ignore_ascii_case(b"OK") {
+        Some(SieveStatus::Ok)
+    } else if token.eq_ignore_ascii_case(b"NO") {
+        Some(SieveStatus::No)
+    } else if token.eq_ignore_ascii_case(b"BYE") {
+        Some(SieveStatus::Bye)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_quoted_capabilities_and_values() {
+        let items = vec![
+            SieveData::line(b"SIEVE \"fileinto vacation\"".to_vec()),
+            SieveData::line(b"IMPLEMENTATION \"Dovecot\"".to_vec()),
+        ];
+
+        let capabilities = parse_capabilities(&items).unwrap();
+        assert_eq!(capabilities[0].name, "SIEVE");
+        assert_eq!(capabilities[0].values, ["fileinto", "vacation"]);
+        assert_eq!(capabilities[1].values, ["Dovecot"]);
+    }
+
+    #[test]
+    fn parses_active_script_and_escapes_names() {
+        let item = SieveData::line(b"\"vac\\\\ation\" ACTIVE".to_vec());
+        let script = parse_script(&item).unwrap();
+        assert_eq!(script.name, "vac\\ation");
+        assert!(script.active);
+        assert_eq!(
+            quote_string(script.name.as_bytes()).unwrap(),
+            b"\"vac\\\\ation\""
+        );
+    }
+
+    #[test]
+    fn parses_literal_script_name_with_suffix() {
+        let item = SieveData::literal(Vec::new(), b"vacation script".to_vec(), b" ACTIVE".to_vec());
+
+        let script = parse_script(&item).unwrap();
+        assert_eq!(script.name, "vacation script");
+        assert!(script.active);
+    }
+
+    #[test]
+    fn parses_literal_capability_name_with_value() {
+        let item = SieveData::literal(
+            Vec::new(),
+            b"IMPLEMENTATION".to_vec(),
+            b" \"Dovecot\"".to_vec(),
+        );
+
+        let capabilities = parse_capabilities(&[item]).unwrap();
+        assert_eq!(capabilities[0].name, "IMPLEMENTATION");
+        assert_eq!(capabilities[0].values, ["Dovecot"]);
+    }
+
+    #[test]
+    fn recognizes_literal_markers() {
+        assert_eq!(literal_size(b"{42}"), Some(42));
+        assert_eq!(literal_size(b"{42+}"), Some(42));
+        assert_eq!(literal_size(b"OK {7}"), Some(7));
+        assert_eq!(literal_size(b"OK {7}   "), Some(7));
+        assert_eq!(literal_size(b"prefix{7}"), None);
+        assert_eq!(literal_size(br#"\"{7}\""#), None);
+        assert_eq!(literal_size(b"{x}"), None);
+    }
+}

--- a/src/sieve/put.rs
+++ b/src/sieve/put.rs
@@ -1,0 +1,22 @@
+use anyhow::Result;
+use clap::Parser;
+use pimalaya_cli::printer::{Message, Printer};
+
+use crate::sieve::{client::SieveClient, script::SieveScriptArg};
+
+/// Validate capacity and upload one server-side Sieve script.
+#[derive(Debug, Parser)]
+pub struct SieveScriptPutCommand {
+    /// The script name.
+    #[arg(value_name = "NAME")]
+    pub name: String,
+    #[command(flatten)]
+    pub script: SieveScriptArg,
+}
+
+impl SieveScriptPutCommand {
+    pub fn execute(self, printer: &mut impl Printer, client: &mut SieveClient) -> Result<()> {
+        client.put_script(&self.name, &self.script.read()?)?;
+        printer.out(Message::new("Sieve script successfully uploaded"))
+    }
+}

--- a/src/sieve/raw.rs
+++ b/src/sieve/raw.rs
@@ -1,0 +1,22 @@
+use anyhow::Result;
+use clap::Parser;
+use pimalaya_cli::printer::{Message, Printer};
+
+use crate::{shared::raw::RawCommandArg, sieve::client::SieveClient};
+
+/// Send one raw ManageSieve command and print its complete response.
+///
+/// Raw is intended for diagnostics and commands not yet modelled by the
+/// high-level API. It accepts one command line; use `put` or `check` for
+/// literal-bearing commands so response framing stays synchronized.
+#[derive(Debug, Parser)]
+pub struct SieveRawCommand {
+    #[command(flatten)]
+    pub command: RawCommandArg,
+}
+
+impl SieveRawCommand {
+    pub fn execute(self, printer: &mut impl Printer, client: &mut SieveClient) -> Result<()> {
+        printer.out(Message::new(client.raw(&self.command.parse()?)?))
+    }
+}

--- a/src/sieve/script.rs
+++ b/src/sieve/script.rs
@@ -1,0 +1,41 @@
+use std::{
+    fs,
+    io::{IsTerminal, Read, stdin},
+    path::PathBuf,
+};
+
+use anyhow::{Context, Result, bail};
+use clap::Parser;
+
+/// Sieve source shared by `put` and `check`.
+#[derive(Debug, Parser)]
+pub struct SieveScriptArg {
+    /// Read the script bytes from a file.
+    #[arg(long = "script-file", value_name = "PATH", conflicts_with = "script")]
+    pub script_file: Option<PathBuf>,
+
+    /// Inline script text, or omit it and pipe the script on stdin.
+    #[arg(name = "script", value_name = "SCRIPT", trailing_var_arg = true)]
+    pub script: Vec<String>,
+}
+
+impl SieveScriptArg {
+    pub fn read(&self) -> Result<Vec<u8>> {
+        if let Some(path) = &self.script_file {
+            return fs::read(path)
+                .with_context(|| format!("Failed to read Sieve script `{}`", path.display()));
+        }
+
+        if !self.script.is_empty() {
+            return Ok(self.script.join(" ").into_bytes());
+        }
+
+        if !stdin().is_terminal() {
+            let mut script = Vec::new();
+            stdin().read_to_end(&mut script)?;
+            return Ok(script);
+        }
+
+        bail!("No Sieve script provided: pass SCRIPT, --script-file, or pipe stdin")
+    }
+}


### PR DESCRIPTION
## Summary

Adds optional ManageSieve support to Himalaya, including account configuration, CLI commands, capability discovery, script lifecycle operations, raw protocol access, JSON schemas, and documentation.

The implementation supports implicit TLS, STARTTLS, LOGIN/PLAIN authentication, quoted strings, literals, and bounded server responses.

## Validation

- cargo test --all-targets: 116 passed
- cargo test --no-default-features --features sieve,rustls-ring: 71 passed
- feature builds for default, IMAP/SMTP, and JMAP
- cargo fmt, cargo deny, diff checks, and Sieve-focused clippy
- live Dovecot ManageSieve tests against two accounts, including STARTTLS, upload, activation, listing, and retrieval

## Notes

The wire implementation currently lives in the optional sieve module because no existing io-sieve crate is available. It can be extracted if preferred by the maintainers.